### PR TITLE
fix(ui): close-to-tray and tray-icon thread bug

### DIFF
--- a/src/Earmark.App/Services/WindowChromeManager.cs
+++ b/src/Earmark.App/Services/WindowChromeManager.cs
@@ -48,7 +48,11 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
         _appWindow = AppWindow.GetFromWindowId(Win32Interop.GetWindowIdFromWindow(_windowHandle));
         _presenter = _appWindow?.Presenter as OverlappedPresenter;
 
-        window.Closed += OnWindowClosed;
+        if (_appWindow is not null)
+        {
+            _appWindow.Closing += OnAppWindowClosing;
+        }
+
         InstallSubclass();
         SyncTrayIcon();
     }
@@ -86,7 +90,21 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
         Microsoft.UI.Xaml.Application.Current.Exit();
     }
 
-    private void OnSettingsChanged(object? sender, EventArgs e) => SyncTrayIcon();
+    private void OnSettingsChanged(object? sender, EventArgs e)
+    {
+        // SettingsService raises this after `ConfigureAwait(false)` so we may be
+        // off the UI thread. The tray icon is a XAML FrameworkElement and its
+        // constructor / Dispose must run on the dispatcher.
+        var dispatcher = _window?.DispatcherQueue;
+        if (dispatcher is null || dispatcher.HasThreadAccess)
+        {
+            SyncTrayIcon();
+        }
+        else
+        {
+            dispatcher.TryEnqueue(SyncTrayIcon);
+        }
+    }
 
     private void SyncTrayIcon()
     {
@@ -148,7 +166,10 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
         _trayIcon = icon;
     }
 
-    private void OnWindowClosed(object sender, WindowEventArgs args)
+    // AppWindow.Closing is the cancellable close event in WinUI 3.
+    // Window.Closed fires after the close is committed and its Handled flag does
+    // not cancel anything, so route through here instead.
+    private void OnAppWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
     {
         if (_exitRequested)
         {
@@ -157,7 +178,7 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
 
         if (_settings.Current.CloseToTray && _settings.Current.ShowTrayIcon)
         {
-            args.Handled = true;
+            args.Cancel = true;
             HideToTray();
         }
     }
@@ -190,9 +211,9 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
     public void Dispose()
     {
         _settings.SettingsChanged -= OnSettingsChanged;
-        if (_window is not null)
+        if (_appWindow is not null)
         {
-            _window.Closed -= OnWindowClosed;
+            _appWindow.Closing -= OnAppWindowClosing;
         }
 
         if (_subclassProc is not null && _windowHandle != 0)


### PR DESCRIPTION
## Summary

Two small bugs in [WindowChromeManager](src/Earmark.App/Services/WindowChromeManager.cs):

1. **Close to tray was a no-op.** The handler was on \`Window.Closed\` setting \`args.Handled = true\` to cancel the close, but in WinUI 3 that flag only stops event bubbling: the close has already committed by the time \`Window.Closed\` fires. Switched to \`AppWindow.Closing\` with \`args.Cancel = true\`, which is the actual cancellable close event.
2. **Toggling any setting threw \`RPC_E_WRONG_THREAD\` (0x8001010E)** inside the \`TaskbarIcon\` constructor. \`SettingsService\` raises \`SettingsChanged\` after \`ConfigureAwait(false)\`, so the handler ran off the UI thread, and \`TaskbarIcon\` is a XAML \`FrameworkElement\` that has to be constructed on the dispatcher. Routed \`SyncTrayIcon\` through the window's \`DispatcherQueue\` whenever we're not already on the UI thread.

## Testing

- [x] Verified clicking the X with \"Close to tray\" enabled hides the window to tray and keeps the process running. Tray menu \"Quit\" still exits cleanly because \`RequestExit\` sets \`_exitRequested = true\` before closing.
- [x] Toggled tray-icon and other settings repeatedly: no exceptions, tray icon appears/disappears correctly.
- [x] App still launches clean and routes apply (Discord -> Comms, msedge -> Media, Default Devices rule fires).