### PR TITLE
ci: add CycloneDX SBOM generation and Dependency-Track upload

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,0 +1,192 @@
+name: SBOM
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CYCLONEDX_DOTNET_VERSION: "4.1.0"
+  DOTNET_SDK_VERSION: "10.0.x"
+  SOLUTION_PATH: Earmark.slnx
+  BOM_FILE: sbom.cdx.json
+
+jobs:
+  branch:
+    name: Branch SBOM
+    if: github.event_name != 'release'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK ${{ env.DOTNET_SDK_VERSION }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+
+      - name: Install CycloneDX .NET tool
+        shell: pwsh
+        run: |
+          $version = $env:CYCLONEDX_DOTNET_VERSION
+          dotnet tool update --global CycloneDX --version $version
+          if ($LASTEXITCODE -ne 0) {
+            dotnet tool install --global CycloneDX --version $version
+          }
+
+      - name: Generate CycloneDX SBOM
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path .sbom-out -Force | Out-Null
+          dotnet CycloneDX $env:SOLUTION_PATH --json --output .sbom-out --filename $env:BOM_FILE
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Move-Item -Path ".sbom-out/$env:BOM_FILE" -Destination $env:BOM_FILE -Force
+          Remove-Item .sbom-out -Recurse -Force
+          Get-Item $env:BOM_FILE
+
+      - name: Upload SBOM as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx-${{ github.ref_name }}
+          path: ${{ env.BOM_FILE }}
+          if-no-files-found: error
+
+      - name: Upload SBOM to Dependency-Track
+        shell: bash
+        env:
+          DT_HOST: ${{ secrets.DT_HOST }}
+          DT_API_KEY: ${{ secrets.DT_API_KEY }}
+          PROJECT_NAME: ${{ github.event.repository.name }}/${{ github.event.repository.name }}
+          PROJECT_VERSION: ${{ github.ref_name }}
+          IS_LATEST: "true"
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DT_HOST:-}" ] || [ -z "${DT_API_KEY:-}" ]; then
+            echo "::warning::DT_HOST or DT_API_KEY secret not set; skipping Dependency-Track upload."
+            exit 0
+          fi
+
+          if [ ! -f "$BOM_FILE" ]; then
+            echo "::error::BOM file not found: $BOM_FILE"
+            exit 1
+          fi
+
+          echo "Uploading $BOM_FILE to Dependency-Track as ${PROJECT_NAME}@${PROJECT_VERSION} (isLatest=${IS_LATEST})"
+
+          HTTP_STATUS=$(curl -sS \
+            -o dt_response.json \
+            -w "%{http_code}" \
+            -X POST "https://${DT_HOST}/api/v1/bom" \
+            -H "X-Api-Key: ${DT_API_KEY}" \
+            -F "autoCreate=true" \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
+            -F "isLatest=${IS_LATEST}" \
+            -F "bom=@${BOM_FILE}")
+
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            echo "Upload accepted (HTTP $HTTP_STATUS)"
+            cat dt_response.json || true
+          else
+            echo "::error::Dependency-Track upload failed with HTTP $HTTP_STATUS"
+            cat dt_response.json || true
+            exit 1
+          fi
+
+  release:
+    name: Release SBOM
+    if: github.event_name == 'release'
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup .NET SDK ${{ env.DOTNET_SDK_VERSION }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+
+      - name: Install CycloneDX .NET tool
+        shell: pwsh
+        run: |
+          $version = $env:CYCLONEDX_DOTNET_VERSION
+          dotnet tool update --global CycloneDX --version $version
+          if ($LASTEXITCODE -ne 0) {
+            dotnet tool install --global CycloneDX --version $version
+          }
+
+      - name: Generate CycloneDX SBOM
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path .sbom-out -Force | Out-Null
+          dotnet CycloneDX $env:SOLUTION_PATH --json --output .sbom-out --filename $env:BOM_FILE
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Move-Item -Path ".sbom-out/$env:BOM_FILE" -Destination $env:BOM_FILE -Force
+          Remove-Item .sbom-out -Recurse -Force
+          Get-Item $env:BOM_FILE
+
+      - name: Upload SBOM as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx-${{ github.event.release.tag_name }}
+          path: ${{ env.BOM_FILE }}
+          if-no-files-found: error
+
+      - name: Attach SBOM to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "${{ env.BOM_FILE }}" --clobber --repo "${{ github.repository }}"
+
+      - name: Upload SBOM to Dependency-Track
+        shell: bash
+        env:
+          DT_HOST: ${{ secrets.DT_HOST }}
+          DT_API_KEY: ${{ secrets.DT_API_KEY }}
+          PROJECT_NAME: ${{ github.event.repository.name }}/releases/${{ github.event.repository.name }}
+          PROJECT_VERSION: ${{ github.event.release.tag_name }}
+          IS_LATEST: "true"
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DT_HOST:-}" ] || [ -z "${DT_API_KEY:-}" ]; then
+            echo "::warning::DT_HOST or DT_API_KEY secret not set; skipping Dependency-Track upload."
+            exit 0
+          fi
+
+          if [ ! -f "$BOM_FILE" ]; then
+            echo "::error::BOM file not found: $BOM_FILE"
+            exit 1
+          fi
+
+          echo "Uploading $BOM_FILE to Dependency-Track as ${PROJECT_NAME}@${PROJECT_VERSION} (isLatest=${IS_LATEST})"
+
+          HTTP_STATUS=$(curl -sS \
+            -o dt_response.json \
+            -w "%{http_code}" \
+            -X POST "https://${DT_HOST}/api/v1/bom" \
+            -H "X-Api-Key: ${DT_API_KEY}" \
+            -F "autoCreate=true" \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
+            -F "isLatest=${IS_LATEST}" \
+            -F "bom=@${BOM_FILE}")
+
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            echo "Upload accepted (HTTP $HTTP_STATUS)"
+            cat dt_response.json || true
+          else
+            echo "::error::Dependency-Track upload failed with HTTP $HTTP_STATUS"
+            cat dt_response.json || true
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Mirror the SBOM flow from the ADO pipelines (\`hoobi-jobs-scheduler\` / \`hoobi-pipeline-tools\`) into this public GitHub repo, with all identifying info kept in secrets.

## Layout in Dependency-Track

Two distinct projects so each carries its own \`isLatest\` pointer:

| Trigger | DT projectName | DT projectVersion |
|---|---|---|
| push to \`main\` | \`{repo}/{repo}\` (e.g. \`earmark/earmark\`) | branch name (\`main\`) |
| release published | \`{repo}/releases/{repo}\` (e.g. \`earmark/releases/earmark\`) | release tag (e.g. \`v0.2.0\`) |

Both upload with \`autoCreate=true\` and \`isLatest=true\`.

The release job also attaches the \`sbom.cdx.json\` to the GitHub Release as a downloadable asset.

## Secrets

This is a public repo, so all identifying info is in secrets. Set these on the repo:

| Secret | Purpose |
|---|---|
| \`DT_HOST\` | Bare hostname of the Dependency-Track server (no scheme, e.g. \`dt.example.com\`). |
| \`DT_API_KEY\` | API key with \`BOM_UPLOAD\` + \`PROJECT_CREATION_UPLOAD\` permissions. |

If either secret is empty the upload step logs a warning and exits 0 cleanly, so forks and dispatch-runs without secrets don't fail.

## Implementation notes

- Generation uses the global CycloneDX \`dotnet\` tool pinned to \`4.1.0\` (matches the ADO template).
- Runs on \`windows-latest\` because \`Earmark.slnx\` targets \`net10.0-windows10.0.26100.0\` and \`dotnet restore\` needs the Windows desktop pack.
- The release event is fired by \`release-please\` using a GitHub App token, which propagates to other workflows (the default \`github.token\` does not, by design).

## Testing

- [ ] Will trigger on the next push to \`main\` (this PR's merge).
- [ ] Release flow tested by the next \`release-please\` release PR being merged.