### PR TITLE
fix(ci): bump CycloneDX tool to 6.1.1 for .slnx support

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -11,7 +11,8 @@ permissions:
   contents: read
 
 env:
-  CYCLONEDX_DOTNET_VERSION: "4.1.0"
+  # 5.1.0+ supports .slnx solution files; pinned to current stable.
+  CYCLONEDX_DOTNET_VERSION: "6.1.1"
   DOTNET_SDK_VERSION: "10.0.x"
   SOLUTION_PATH: Earmark.slnx
   BOM_FILE: sbom.cdx.json


### PR DESCRIPTION
## Summary

Previous SBOM workflow run [#24933126411](https://github.com/hoobio/earmark/actions/runs/24933126411/job/73014084062) failed:

\`\`\`
Scanning at D:\a\earmark\earmark\Earmark.slnx
Only .sln, .csproj, .fsproj, .vbproj, .xsproj, and packages.config files are supported
\`\`\`

The pinned CycloneDX .NET tool 4.1.0 predates \`.slnx\` support. Per the [cyclonedx-dotnet changelog](https://github.com/CycloneDX/cyclonedx-dotnet/releases), \`.slnx\` was added in **5.1.0**. Bumping the pin to **6.1.1** (current stable on NuGet) keeps the workflow pointing at \`Earmark.slnx\` as originally written.