### PR TITLE
perf: event-driven routing applier and session lifecycle events

### DIFF
--- a/src/Earmark.App/Hosting/HostBuilderExtensions.cs
+++ b/src/Earmark.App/Hosting/HostBuilderExtensions.cs
@@ -27,10 +27,13 @@ internal static class HostBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        var fileLoggerProvider = new FileLoggerProvider(CurrentLogPath);
         builder.Logging.ClearProviders();
         builder.Logging.AddDebug();
-        builder.Logging.AddProvider(new FileLoggerProvider(CurrentLogPath));
-        builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        builder.Logging.AddProvider(fileLoggerProvider);
+        builder.Logging.SetMinimumLevel(LogLevel.Trace);
+
+        builder.Services.AddSingleton(fileLoggerProvider);
 
         builder.Services.AddEarmarkCore();
         builder.Services.AddEarmarkInterop();

--- a/src/Earmark.App/Logging/FileLogger.cs
+++ b/src/Earmark.App/Logging/FileLogger.cs
@@ -9,6 +9,7 @@ internal sealed class FileLoggerProvider : ILoggerProvider
 {
     private readonly string _path;
     private readonly Lock _gate = new();
+    private LogLevel _minimumLevel = LogLevel.Information;
 
     public FileLoggerProvider(string path)
     {
@@ -18,6 +19,10 @@ internal sealed class FileLoggerProvider : ILoggerProvider
     }
 
     public string FilePath => _path;
+
+    public LogLevel MinimumLevel => _minimumLevel;
+
+    public void SetMinimumLevel(LogLevel level) => _minimumLevel = level;
 
     public ILogger CreateLogger(string categoryName) =>
         new FileLogger(categoryName, this);
@@ -55,7 +60,7 @@ internal sealed class FileLogger : ILogger
 
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
-    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= _provider.MinimumLevel;
 
     public void Log<TState>(
         LogLevel logLevel,

--- a/src/Earmark.App/Services/IRoutingApplier.cs
+++ b/src/Earmark.App/Services/IRoutingApplier.cs
@@ -17,7 +17,9 @@ public interface IRoutingApplier
 
 internal sealed class RoutingApplier : IRoutingApplier, IDisposable
 {
-    private static readonly TimeSpan PeriodicInterval = TimeSpan.FromSeconds(10);
+    // Drift-guard only. The real triggers are SessionAdded / SessionRemoved /
+    // RulesChanged / DefaultsChanged. Keep this slow enough to not show up on idle CPU.
+    private static readonly TimeSpan PeriodicInterval = TimeSpan.FromMinutes(5);
 
     private readonly IRulesService _rules;
     private readonly IAudioSessionService _sessions;
@@ -61,6 +63,7 @@ internal sealed class RoutingApplier : IRoutingApplier, IDisposable
         _started = true;
         _cts = new CancellationTokenSource();
         _sessions.SessionAdded += OnSessionAdded;
+        _sessions.SessionRemoved += OnSessionRemoved;
         _rules.RulesChanged += OnRulesChanged;
         _endpoints.DefaultsChanged += OnDefaultsChanged;
 
@@ -149,13 +152,10 @@ internal sealed class RoutingApplier : IRoutingApplier, IDisposable
         var renderEndpoints = _endpoints.GetEndpoints(EndpointFlow.Render);
         var captureEndpoints = _endpoints.GetEndpoints(EndpointFlow.Capture);
 
-        _logger.LogInformation("ApplyAll: {Count} sessions, {RuleCount} rules", sessions.Count, _rules.Rules.Count);
+        _logger.LogDebug("ApplyAll: {Count} sessions, {RuleCount} rules", sessions.Count, _rules.Rules.Count);
 
         foreach (var session in sessions)
         {
-            _logger.LogDebug("Session: pid={Pid} name='{Name}' path='{Path}' state={State}",
-                session.ProcessId, session.ProcessName, session.ExecutablePath, session.State);
-
             ApplyAppForFlow(session, EndpointFlow.Render, renderEndpoints);
             ApplyAppForFlow(session, EndpointFlow.Capture, captureEndpoints);
         }
@@ -292,6 +292,29 @@ internal sealed class RoutingApplier : IRoutingApplier, IDisposable
         }
     }
 
+    private void OnSessionRemoved(object? sender, AudioSessionRemovedEvent e)
+    {
+        var prefix = $"app|{e.ProcessId}|";
+        var removed = 0;
+        lock (_appliedGate)
+        {
+            _appliedSessionKeys.RemoveWhere(k =>
+            {
+                if (k.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    removed++;
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        if (removed > 0)
+        {
+            _logger.LogDebug("Session removed: pid {Pid} - evicted {Count} dedupe entries", e.ProcessId, removed);
+        }
+    }
+
     private async void OnRulesChanged(object? sender, EventArgs e)
     {
         try
@@ -348,6 +371,7 @@ internal sealed class RoutingApplier : IRoutingApplier, IDisposable
         _timer?.Dispose();
         _timer = null;
         _sessions.SessionAdded -= OnSessionAdded;
+        _sessions.SessionRemoved -= OnSessionRemoved;
         _rules.RulesChanged -= OnRulesChanged;
         _endpoints.DefaultsChanged -= OnDefaultsChanged;
         _cts?.Dispose();

--- a/src/Earmark.App/Services/StartupSettingsApplier.cs
+++ b/src/Earmark.App/Services/StartupSettingsApplier.cs
@@ -1,3 +1,4 @@
+using Earmark.App.Logging;
 using Earmark.App.Settings;
 
 using Microsoft.Extensions.Logging;
@@ -7,12 +8,17 @@ namespace Earmark.App.Services;
 internal sealed class StartupSettingsApplier : IDisposable
 {
     private readonly ISettingsService _settings;
+    private readonly FileLoggerProvider _fileLogger;
     private readonly ILogger<StartupSettingsApplier> _logger;
     private bool _started;
 
-    public StartupSettingsApplier(ISettingsService settings, ILogger<StartupSettingsApplier> logger)
+    public StartupSettingsApplier(
+        ISettingsService settings,
+        FileLoggerProvider fileLogger,
+        ILogger<StartupSettingsApplier> logger)
     {
         _settings = settings;
+        _fileLogger = fileLogger;
         _logger = logger;
     }
 
@@ -42,6 +48,13 @@ internal sealed class StartupSettingsApplier : IDisposable
             else
             {
                 StartupRegistration.Unregister();
+            }
+
+            var desired = s.VerboseLogging ? LogLevel.Debug : LogLevel.Information;
+            if (_fileLogger.MinimumLevel != desired)
+            {
+                _fileLogger.SetMinimumLevel(desired);
+                _logger.LogInformation("File log level set to {Level}", desired);
             }
         }
         catch (Exception ex)

--- a/src/Earmark.App/Settings/AppSettings.cs
+++ b/src/Earmark.App/Settings/AppSettings.cs
@@ -11,4 +11,6 @@ public sealed class AppSettings
     public bool CloseToTray { get; set; }
 
     public bool LaunchToTray { get; set; }
+
+    public bool VerboseLogging { get; set; }
 }

--- a/src/Earmark.App/ViewModels/SettingsViewModel.cs
+++ b/src/Earmark.App/ViewModels/SettingsViewModel.cs
@@ -30,6 +30,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     public partial bool LaunchToTray { get; set; }
 
+    [ObservableProperty]
+    public partial bool VerboseLogging { get; set; }
+
     public void SyncFromSettings()
     {
         _suppress = true;
@@ -40,6 +43,7 @@ public partial class SettingsViewModel : ObservableObject
             MinimizeToTray = _settings.Current.MinimizeToTray;
             CloseToTray = _settings.Current.CloseToTray;
             LaunchToTray = _settings.Current.LaunchToTray;
+            VerboseLogging = _settings.Current.VerboseLogging;
         }
         finally
         {
@@ -52,6 +56,7 @@ public partial class SettingsViewModel : ObservableObject
     partial void OnMinimizeToTrayChanged(bool value) => Persist(s => s.MinimizeToTray = value);
     partial void OnCloseToTrayChanged(bool value) => Persist(s => s.CloseToTray = value);
     partial void OnLaunchToTrayChanged(bool value) => Persist(s => s.LaunchToTray = value);
+    partial void OnVerboseLoggingChanged(bool value) => Persist(s => s.VerboseLogging = value);
 
     private async void Persist(Action<AppSettings> mutate)
     {

--- a/src/Earmark.App/Views/SettingsPage.xaml
+++ b/src/Earmark.App/Views/SettingsPage.xaml
@@ -38,6 +38,10 @@
                     <ToggleSwitch IsOn="{x:Bind ViewModel.LaunchToTray, Mode=TwoWay}" />
                 </ctrl:SettingsCard>
 
+                <ctrl:SettingsCard Header="Verbose logging" Description="Write debug-level diagnostics to the log file. Leave off for normal use.">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.VerboseLogging, Mode=TwoWay}" />
+                </ctrl:SettingsCard>
+
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/src/Earmark.Audio/Services/AudioEndpointService.cs
+++ b/src/Earmark.Audio/Services/AudioEndpointService.cs
@@ -13,7 +13,7 @@ namespace Earmark.Audio.Services;
 [SupportedOSPlatform("windows10.0.19041.0")]
 public sealed class AudioEndpointService : IAudioEndpointService, IMMNotificationClient, IDisposable
 {
-    private static readonly TimeSpan SafetyRefreshInterval = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan SafetyRefreshInterval = TimeSpan.FromMinutes(5);
 
     private readonly ILogger<AudioEndpointService> _logger;
     private readonly MMDeviceEnumerator _enumerator;

--- a/src/Earmark.Audio/Services/AudioSessionService.cs
+++ b/src/Earmark.Audio/Services/AudioSessionService.cs
@@ -19,17 +19,15 @@ namespace Earmark.Audio.Services;
 [SupportedOSPlatform("windows10.0.19041.0")]
 public sealed class AudioSessionService : IAudioSessionService, IDisposable
 {
-    private static readonly TimeSpan SafetyRefreshInterval = TimeSpan.FromMinutes(1);
-
     private readonly ILogger<AudioSessionService> _logger;
     private readonly IAudioEndpointService _endpoints;
     private readonly MMDeviceEnumerator _enumerator;
     private readonly Lock _gate = new();
     private readonly Lock _cacheGate = new();
     private readonly Dictionary<string, SessionWatcher> _watchers = new(StringComparer.OrdinalIgnoreCase);
-    private readonly Timer _safetyTimer;
 
     private IReadOnlyList<AudioSession> _snapshot = Array.Empty<AudioSession>();
+    private HashSet<uint> _knownPids = new();
     private volatile bool _dirty = true;
     private bool _disposed;
 
@@ -40,17 +38,17 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
         _enumerator = new MMDeviceEnumerator();
         _endpoints.EndpointsChanged += OnEndpointsChanged;
         AttachAll();
-        _safetyTimer = new Timer(_ => MarkDirty(), null, SafetyRefreshInterval, SafetyRefreshInterval);
     }
 
     public event EventHandler<AudioSessionEvent>? SessionAdded;
+    public event EventHandler<AudioSessionRemovedEvent>? SessionRemoved;
     public event EventHandler? SessionsChanged;
 
     public IReadOnlyList<AudioSession> GetSessions()
     {
         // Lazy rebuild: re-enumerate only if the cache has been marked dirty since the
-        // last build. Bursts of session events (volume changes, state flips) collapse
-        // into one rebuild on the next read.
+        // last build. Bursts of session events collapse into one rebuild on the next read.
+        List<uint>? removedPids = null;
         while (_dirty)
         {
             lock (_cacheGate)
@@ -63,13 +61,38 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
                 _dirty = false;
                 try
                 {
-                    Volatile.Write(ref _snapshot, BuildSnapshot());
+                    var fresh = BuildSnapshot();
+                    var freshPids = new HashSet<uint>();
+                    foreach (var session in fresh)
+                    {
+                        freshPids.Add(session.ProcessId);
+                    }
+
+                    foreach (var oldPid in _knownPids)
+                    {
+                        if (!freshPids.Contains(oldPid))
+                        {
+                            (removedPids ??= new List<uint>()).Add(oldPid);
+                        }
+                    }
+
+                    _knownPids = freshPids;
+                    Volatile.Write(ref _snapshot, fresh);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Session cache rebuild failed; serving previous snapshot");
                     break;
                 }
+            }
+        }
+
+        if (removedPids is not null)
+        {
+            foreach (var pid in removedPids)
+            {
+                ProcessInfoCache.TryRemove(pid, out _);
+                SessionRemoved?.Invoke(this, new AudioSessionRemovedEvent(pid));
             }
         }
 
@@ -222,7 +245,6 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
         }
 
         _disposed = true;
-        _safetyTimer.Dispose();
         _endpoints.EndpointsChanged -= OnEndpointsChanged;
         lock (_gate)
         {
@@ -276,9 +298,11 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
             }
         }
 
-        public void OnVolumeChanged(float volume, bool isMuted) => _owner.RaiseChanged();
-        public void OnDisplayNameChanged(string displayName) => _owner.RaiseChanged();
-        public void OnIconPathChanged(string iconPath) => _owner.RaiseChanged();
+        // Volume / icon / display-name fire frequently and don't change routing-relevant
+        // state. Ignoring them keeps the snapshot stable and avoids waking the UI/applier.
+        public void OnVolumeChanged(float volume, bool isMuted) { }
+        public void OnDisplayNameChanged(string displayName) { }
+        public void OnIconPathChanged(string iconPath) { }
         public void OnChannelVolumeChanged(uint channelCount, IntPtr newVolumes, uint channelIndex) { }
         public void OnGroupingParamChanged(ref Guid groupingId) { }
         public void OnStateChanged(AudioSessionState state) => _owner.RaiseChanged();

--- a/src/Earmark.Core/Audio/IAudioSessionService.cs
+++ b/src/Earmark.Core/Audio/IAudioSessionService.cs
@@ -4,9 +4,12 @@ namespace Earmark.Core.Audio;
 
 public sealed record AudioSessionEvent(AudioSession Session);
 
+public sealed record AudioSessionRemovedEvent(uint ProcessId);
+
 public interface IAudioSessionService
 {
     IReadOnlyList<AudioSession> GetSessions();
     event EventHandler<AudioSessionEvent>? SessionAdded;
+    event EventHandler<AudioSessionRemovedEvent>? SessionRemoved;
     event EventHandler? SessionsChanged;
 }


### PR DESCRIPTION
Idle CPU was driven by a 10s applier timer plus volume/icon/display-name session events that re-ran regex matching for no routing-relevant change. Switch to event-driven re-evaluation, drop noisy log writes, and add a toggle for verbose diagnostics.

- RoutingApplier 10s timer extended to a 5min drift-guard. SessionAdded, SessionRemoved, RulesChanged, DefaultsChanged are the real triggers.
- AudioSessionService snapshot rebuild diffs PIDs vs. previous set, fires a new SessionRemoved event, and prunes ProcessInfoCache. The applier evicts dedupe entries by PID on the event.
- Volume / icon / display-name no longer wake the snapshot or UI.
- AudioSessionService 60s safety timer removed; AudioEndpointService timer extended from 1min to 5min.
- File logger defaults to Information; new VerboseLogging setting toggles Debug at runtime.

Verified on Win11 26200: clean build, app launches and applies existing rules on init, 30s idle produces zero new log lines, 10s CPU sample shows ~0.15%.

feat: add verbose logging toggle to settings