### PR TITLE
feat: WiX 5 MSI installer alongside MSIX

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ env:
   # NOTE: GitHub Actions does not allow expressions in `uses:` refs, so the
   # pipeline-tools pin is repeated in each `uses:` line below. Bump in lockstep.
   # Current pin: hoobio/pipeline-tools @ feat/wix-msi-helpers HEAD
-  # (d48c7263c2bc532fd2ddf3e3a8a20e6f1f38e77b). Bump to a tagged release
+  # (89bcb15766b1a2b10c0dbcab0e7416836b452e36). Bump to a tagged release
   # before merge.
 
 jobs:
@@ -105,6 +105,26 @@ jobs:
           platform: ${{ matrix.platform }}
           output-dir: ${{ github.workspace }}\AppPackages
 
+      # `dotnet publish` lands the MSIX nested under
+      # AppPackages\Earmark.App_<v>.<rev>_<plat>_Test\Earmark.App_<v>.<rev>_<plat>.msix.
+      # Stage it to a flat directory under a consistent name so the signing step,
+      # artifact upload, and release attachment all see a clean path.
+      - name: Stage MSIX
+        shell: pwsh
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          VERSION: ${{ steps.version.outputs.version }}
+          STAGE_DIR: ${{ github.workspace }}\staging\msix-${{ matrix.platform }}
+        run: |
+          $msix = Get-ChildItem -Path "${{ github.workspace }}\AppPackages" -Recurse -Filter *.msix -ErrorAction Stop |
+            Where-Object { $_.FullName -notmatch '\\Dependencies\\' } |
+            Select-Object -First 1
+          if (-not $msix) { throw "No MSIX produced by dotnet publish" }
+          New-Item -ItemType Directory -Path $env:STAGE_DIR -Force | Out-Null
+          $dest = Join-Path $env:STAGE_DIR ("Earmark-{0}-{1}.msix" -f $env:VERSION, $env:PLATFORM)
+          Copy-Item -LiteralPath $msix.FullName -Destination $dest -Force
+          Write-Host "Staged MSIX: $dest"
+
       - name: Sign MSIX
         if: env.HAS_SIGNING_CERT == 'true'
         uses: hoobio/pipeline-tools/pipeline/github/step/sign-msix@v1.2.0
@@ -112,7 +132,7 @@ jobs:
           pfx-base64: ${{ secrets.SIGNING_CERTIFICATE }}
           pfx-password: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
           thumbprint: ${{ vars.SIGNING_CERT_THUMBPRINT }}
-          packages-path: ${{ github.workspace }}\AppPackages
+          packages-path: ${{ github.workspace }}\staging\msix-${{ matrix.platform }}
 
       - name: Skip-sign notice
         if: env.HAS_SIGNING_CERT != 'true'
@@ -123,7 +143,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: msix-${{ matrix.platform }}
-          path: ${{ github.workspace }}\AppPackages\**\*.msix
+          path: ${{ github.workspace }}\staging\msix-${{ matrix.platform }}\Earmark-${{ steps.version.outputs.version }}-${{ matrix.platform }}.msix
           if-no-files-found: error
 
   build-msi:
@@ -181,22 +201,23 @@ jobs:
           }
 
       - name: Build MSI
-        uses: hoobio/pipeline-tools/pipeline/github/step/build-msi-wix@d48c7263c2bc532fd2ddf3e3a8a20e6f1f38e77b
+        uses: hoobio/pipeline-tools/pipeline/github/step/build-msi-wix@89bcb15766b1a2b10c0dbcab0e7416836b452e36
         with:
           wix-source-path: ${{ env.WIX_SOURCE_PATH }}
           version: ${{ steps.version.outputs.version }}
           platform: ${{ matrix.platform }}
           payload-dir: ${{ github.workspace }}\publish\${{ matrix.platform }}
-          output-dir: ${{ github.workspace }}\MsiPackages\${{ matrix.platform }}
+          output-dir: ${{ github.workspace }}\staging\msi-${{ matrix.platform }}
+          extensions: "WixToolset.UI.wixext,WixToolset.Util.wixext"
 
       - name: Sign MSI
         if: env.HAS_SIGNING_CERT == 'true'
-        uses: hoobio/pipeline-tools/pipeline/github/step/sign-msi@d48c7263c2bc532fd2ddf3e3a8a20e6f1f38e77b
+        uses: hoobio/pipeline-tools/pipeline/github/step/sign-msi@89bcb15766b1a2b10c0dbcab0e7416836b452e36
         with:
           pfx-base64: ${{ secrets.SIGNING_CERTIFICATE }}
           pfx-password: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
           thumbprint: ${{ vars.SIGNING_CERT_THUMBPRINT }}
-          packages-path: ${{ github.workspace }}\MsiPackages\${{ matrix.platform }}
+          packages-path: ${{ github.workspace }}\staging\msi-${{ matrix.platform }}
 
       - name: Skip-sign notice
         if: env.HAS_SIGNING_CERT != 'true'
@@ -207,7 +228,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: msi-${{ matrix.platform }}
-          path: ${{ github.workspace }}\MsiPackages\${{ matrix.platform }}\*.msi
+          path: ${{ github.workspace }}\staging\msi-${{ matrix.platform }}\Earmark-${{ steps.version.outputs.version }}-${{ matrix.platform }}.msi
           if-no-files-found: error
 
   wack:
@@ -316,6 +337,10 @@ jobs:
       attestations: write
       contents: write
     steps:
+      # Download every artefact into a single tree under `release/`. Each
+      # artefact's contents already sit at the root of its own folder (the
+      # build/wack/sbom jobs stage to flat dirs first), so the attach step can
+      # just glob across `release/**` for raw files.
       - name: Download MSIX (x64)
         uses: actions/download-artifact@v8
         with:
@@ -341,32 +366,39 @@ jobs:
         with:
           name: sbom
           path: release/sbom
+      - name: Download WACK report (x64)
+        uses: actions/download-artifact@v8
+        with:
+          name: wack-report-x64
+          path: release/wack-x64
+      - name: Download WACK report (ARM64)
+        uses: actions/download-artifact@v8
+        with:
+          name: wack-report-ARM64
+          path: release/wack-ARM64
 
-      - name: Attest MSIX provenance
+      - name: Attest installer provenance
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: "release/msix-*/**/*.msix"
+          subject-path: "release/msix-*/*.msix,release/msi-*/*.msi"
 
-      - name: Attest MSI provenance
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: "release/msi-*/**/*.msi"
-
-      - name: Attach SBOM to draft release
-        uses: hoobio/pipeline-tools/pipeline/github/step/upload-to-github-release@v1.2.0
-        with:
-          tag: ${{ needs.release-please.outputs.tag_name }}
-          file-path: release/sbom/${{ env.BOM_FILE }}
-          github-token: ${{ github.token }}
-
-      - name: Attach packages to draft release
+      - name: Attach all artefacts to draft release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
-          mapfile -t PACKAGE_FILES < <(find release/msix-x64 release/msix-ARM64 release/msi-x64 release/msi-ARM64 -type f \( -name '*.msix' -o -name '*.msi' \))
-          gh release upload "$TAG" "${PACKAGE_FILES[@]}" --clobber --repo "${{ github.repository }}"
+          mapfile -t RELEASE_FILES < <(find release -type f \( \
+            -name '*.msix' -o \
+            -name '*.msi'  -o \
+            -name '*.cdx.json' -o \
+            -name 'wack-report-*.xml' \))
+          if [ "${#RELEASE_FILES[@]}" -eq 0 ]; then
+            echo "::error::No release files found to attach"
+            exit 1
+          fi
+          printf 'Attaching: %s\n' "${RELEASE_FILES[@]}"
+          gh release upload "$TAG" "${RELEASE_FILES[@]}" --clobber --repo "${{ github.repository }}"
 
       - name: Publish draft release
         uses: hoobio/pipeline-tools/pipeline/github/step/publish-github-release@v1.2.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -208,7 +208,10 @@ jobs:
           platform: ${{ matrix.platform }}
           payload-dir: ${{ github.workspace }}\publish\${{ matrix.platform }}
           output-dir: ${{ github.workspace }}\staging\msi-${{ matrix.platform }}
-          extensions: "WixToolset.UI.wixext,WixToolset.Util.wixext"
+          # Pin extensions to 5.x; the unversioned form pulls the latest (currently
+          # 7.0.0), which fails with "Could not find expected package root folder
+          # wixext5. Ensure WixToolset.UI.wixext/7.0.0 is compatible with WiX v5."
+          extensions: "WixToolset.UI.wixext/5.0.2,WixToolset.Util.wixext/5.0.2"
 
       - name: Sign MSI
         if: env.HAS_SIGNING_CERT == 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,10 +18,13 @@ env:
   SOLUTION_PATH: Earmark.slnx
   PROJECT_PATH: src/Earmark.App/Earmark.App.csproj
   APPXMANIFEST_PATH: src/Earmark.App/Package.appxmanifest
+  WIX_SOURCE_PATH: installer/Earmark.wxs
   BOM_FILE: sbom.cdx.json
   # NOTE: GitHub Actions does not allow expressions in `uses:` refs, so the
   # pipeline-tools pin is repeated in each `uses:` line below. Bump in lockstep.
-  # Current pin: hoobio/pipeline-tools @ v1.2.0 (immutable release).
+  # Current pin: hoobio/pipeline-tools @ feat/wix-msi-helpers HEAD
+  # (d48c7263c2bc532fd2ddf3e3a8a20e6f1f38e77b). Bump to a tagged release
+  # before merge.
 
 jobs:
   release-please:
@@ -123,6 +126,90 @@ jobs:
           path: ${{ github.workspace }}\AppPackages\**\*.msix
           if-no-files-found: error
 
+  build-msi:
+    name: Build MSI (${{ matrix.platform }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x64, ARM64]
+    env:
+      HAS_SIGNING_CERT: ${{ secrets.SIGNING_CERTIFICATE != '' && vars.SIGNING_CERT_THUMBPRINT != '' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+
+      - name: Read version
+        id: version
+        shell: pwsh
+        run: |
+          $ver = (Get-Content version.txt -Raw).Trim()
+          "version=$ver" | Out-File -Append $env:GITHUB_OUTPUT
+          "APP_VERSION=$ver" | Out-File -Append $env:GITHUB_ENV
+
+      - name: Resolve runtime identifier
+        id: rid
+        shell: pwsh
+        run: |
+          $rid = if ($env:PLATFORM -eq 'ARM64') { 'win-arm64' } else { 'win-x64' }
+          "rid=$rid" | Out-File -Append $env:GITHUB_OUTPUT
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Publish unpackaged self-contained build
+        shell: pwsh
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          RID: ${{ steps.rid.outputs.rid }}
+          PUBLISH_DIR: ${{ github.workspace }}\publish\${{ matrix.platform }}
+        run: |
+          New-Item -ItemType Directory -Path $env:PUBLISH_DIR -Force | Out-Null
+          dotnet publish $env:PROJECT_PATH `
+            -c Release `
+            -p:Platform=$env:PLATFORM `
+            -p:RuntimeIdentifier=$env:RID `
+            -p:WindowsPackageType=None `
+            -p:WindowsAppSDKSelfContained=true `
+            -p:SelfContained=true `
+            -o $env:PUBLISH_DIR
+          if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed (exit $LASTEXITCODE)" }
+          if (-not (Test-Path "$env:PUBLISH_DIR\Earmark.App.exe")) {
+            throw "Expected Earmark.App.exe in publish output"
+          }
+
+      - name: Build MSI
+        uses: hoobio/pipeline-tools/pipeline/github/step/build-msi-wix@d48c7263c2bc532fd2ddf3e3a8a20e6f1f38e77b
+        with:
+          wix-source-path: ${{ env.WIX_SOURCE_PATH }}
+          version: ${{ steps.version.outputs.version }}
+          platform: ${{ matrix.platform }}
+          payload-dir: ${{ github.workspace }}\publish\${{ matrix.platform }}
+          output-dir: ${{ github.workspace }}\MsiPackages\${{ matrix.platform }}
+
+      - name: Sign MSI
+        if: env.HAS_SIGNING_CERT == 'true'
+        uses: hoobio/pipeline-tools/pipeline/github/step/sign-msi@d48c7263c2bc532fd2ddf3e3a8a20e6f1f38e77b
+        with:
+          pfx-base64: ${{ secrets.SIGNING_CERTIFICATE }}
+          pfx-password: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
+          thumbprint: ${{ vars.SIGNING_CERT_THUMBPRINT }}
+          packages-path: ${{ github.workspace }}\MsiPackages\${{ matrix.platform }}
+
+      - name: Skip-sign notice
+        if: env.HAS_SIGNING_CERT != 'true'
+        shell: bash
+        run: echo "::warning::SIGNING_CERTIFICATE / SIGNING_CERT_THUMBPRINT not set; MSI produced unsigned."
+
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: msi-${{ matrix.platform }}
+          path: ${{ github.workspace }}\MsiPackages\${{ matrix.platform }}\*.msi
+          if-no-files-found: error
+
   wack:
     name: WACK (${{ matrix.platform }})
     needs: [build-msix]
@@ -214,12 +301,13 @@ jobs:
 
   release:
     name: Publish Release
-    needs: [release-please, lint-and-test, build-msix, wack, sbom]
+    needs: [release-please, lint-and-test, build-msix, build-msi, wack, sbom]
     if: >-
       always()
       && needs.release-please.outputs.release_created == 'true'
       && needs.lint-and-test.result == 'success'
       && needs.build-msix.result == 'success'
+      && needs.build-msi.result == 'success'
       && needs.wack.result == 'success'
       && needs.sbom.result == 'success'
     runs-on: ubuntu-latest
@@ -238,6 +326,16 @@ jobs:
         with:
           name: msix-ARM64
           path: release/msix-ARM64
+      - name: Download MSI (x64)
+        uses: actions/download-artifact@v8
+        with:
+          name: msi-x64
+          path: release/msi-x64
+      - name: Download MSI (ARM64)
+        uses: actions/download-artifact@v8
+        with:
+          name: msi-ARM64
+          path: release/msi-ARM64
       - name: Download SBOM
         uses: actions/download-artifact@v8
         with:
@@ -249,6 +347,11 @@ jobs:
         with:
           subject-path: "release/msix-*/**/*.msix"
 
+      - name: Attest MSI provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: "release/msi-*/**/*.msi"
+
       - name: Attach SBOM to draft release
         uses: hoobio/pipeline-tools/pipeline/github/step/upload-to-github-release@v1.2.0
         with:
@@ -256,14 +359,14 @@ jobs:
           file-path: release/sbom/${{ env.BOM_FILE }}
           github-token: ${{ github.token }}
 
-      - name: Attach MSIX packages to draft release
+      - name: Attach packages to draft release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
-          mapfile -t MSIX_FILES < <(find release/msix-x64 release/msix-ARM64 -type f -name '*.msix')
-          gh release upload "$TAG" "${MSIX_FILES[@]}" --clobber --repo "${{ github.repository }}"
+          mapfile -t PACKAGE_FILES < <(find release/msix-x64 release/msix-ARM64 release/msi-x64 release/msi-ARM64 -type f \( -name '*.msix' -o -name '*.msi' \))
+          gh release upload "$TAG" "${PACKAGE_FILES[@]}" --clobber --repo "${{ github.repository }}"
 
       - name: Publish draft release
         uses: hoobio/pipeline-tools/pipeline/github/step/publish-github-release@v1.2.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,9 +22,8 @@ env:
   BOM_FILE: sbom.cdx.json
   # NOTE: GitHub Actions does not allow expressions in `uses:` refs, so the
   # pipeline-tools pin is repeated in each `uses:` line below. Bump in lockstep.
-  # Current pin: hoobio/pipeline-tools @ feat/wix-msi-helpers HEAD
-  # (89bcb15766b1a2b10c0dbcab0e7416836b452e36). Bump to a tagged release
-  # before merge.
+  # Current pin: hoobio/pipeline-tools @ v1.3.0 (immutable release - adds the
+  # build-msi-wix and sign-msi composite actions).
 
 jobs:
   release-please:
@@ -36,7 +35,7 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - id: rp
-        uses: hoobio/pipeline-tools/pipeline/github/step/release-please@v1.2.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/release-please@v1.3.0
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
           app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
@@ -93,13 +92,13 @@ jobs:
           "APP_VERSION=$ver" | Out-File -Append $env:GITHUB_ENV
 
       - name: Stamp Package.appxmanifest version
-        uses: hoobio/pipeline-tools/pipeline/github/step/stamp-msix-version@v1.2.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/stamp-msix-version@v1.3.0
         with:
           manifest-path: ${{ env.APPXMANIFEST_PATH }}
           version: ${{ steps.version.outputs.version }}
 
       - name: Build MSIX
-        uses: hoobio/pipeline-tools/pipeline/github/step/build-msix-dotnet@v1.2.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/build-msix-dotnet@v1.3.0
         with:
           project-path: ${{ env.PROJECT_PATH }}
           platform: ${{ matrix.platform }}
@@ -127,7 +126,7 @@ jobs:
 
       - name: Sign MSIX
         if: env.HAS_SIGNING_CERT == 'true'
-        uses: hoobio/pipeline-tools/pipeline/github/step/sign-msix@v1.2.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/sign-msix@v1.3.0
         with:
           pfx-base64: ${{ secrets.SIGNING_CERTIFICATE }}
           pfx-password: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
@@ -201,7 +200,7 @@ jobs:
           }
 
       - name: Build MSI
-        uses: hoobio/pipeline-tools/pipeline/github/step/build-msi-wix@89bcb15766b1a2b10c0dbcab0e7416836b452e36
+        uses: hoobio/pipeline-tools/pipeline/github/step/build-msi-wix@v1.3.0
         with:
           wix-source-path: ${{ env.WIX_SOURCE_PATH }}
           version: ${{ steps.version.outputs.version }}
@@ -215,7 +214,7 @@ jobs:
 
       - name: Sign MSI
         if: env.HAS_SIGNING_CERT == 'true'
-        uses: hoobio/pipeline-tools/pipeline/github/step/sign-msi@89bcb15766b1a2b10c0dbcab0e7416836b452e36
+        uses: hoobio/pipeline-tools/pipeline/github/step/sign-msi@v1.3.0
         with:
           pfx-base64: ${{ secrets.SIGNING_CERTIFICATE }}
           pfx-password: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
@@ -255,7 +254,7 @@ jobs:
           path: msix
 
       - name: Run WACK
-        uses: hoobio/pipeline-tools/pipeline/github/step/run-wack@v1.2.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/run-wack@v1.3.0
         with:
           msix-path: msix
           report-path: wack-report-${{ matrix.platform }}.xml
@@ -289,7 +288,7 @@ jobs:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Generate CycloneDX SBOM
-        uses: hoobio/pipeline-tools/pipeline/github/step/cyclonedx-sbom-dotnet@v1.2.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/cyclonedx-sbom-dotnet@v1.3.0
         with:
           solution-path: ${{ env.SOLUTION_PATH }}
           output-path: ${{ env.BOM_FILE }}
@@ -303,7 +302,7 @@ jobs:
 
       - name: Upload SBOM to Dependency-Track
         if: env.DT_HOST != '' && env.DT_API_KEY != ''
-        uses: hoobio/pipeline-tools/pipeline/github/job/upload-sbom-to-dependency-track@v1.2.0
+        uses: hoobio/pipeline-tools/pipeline/github/job/upload-sbom-to-dependency-track@v1.3.0
         with:
           bom-path: ${{ env.BOM_FILE }}
           upload-artifact: 'false'
@@ -404,7 +403,7 @@ jobs:
           gh release upload "$TAG" "${RELEASE_FILES[@]}" --clobber --repo "${{ github.repository }}"
 
       - name: Publish draft release
-        uses: hoobio/pipeline-tools/pipeline/github/step/publish-github-release@v1.2.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/publish-github-release@v1.3.0
         with:
           tag: ${{ needs.release-please.outputs.tag_name }}
           github-token: ${{ github.token }}

--- a/installer/Earmark.wxs
+++ b/installer/Earmark.wxs
@@ -47,7 +47,14 @@
 
     <Media Id="1" Cabinet="Earmark.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <Icon Id="EarmarkIcon" SourceFile="$(var.PayloadDir)\Assets\AppIcon.ico" />
+    <!--
+      Resolved relative to this .wxs file (installer\), so the icon comes from
+      the source tree rather than the published payload. The unpackaged WinUI
+      publish output doesn't include the Content asset folder, but the icon is
+      only needed at install time for the ARP entry and shortcut, not at
+      runtime, so referencing the source path is correct.
+    -->
+    <Icon Id="EarmarkIcon" SourceFile="$(sys.SOURCEFILEDIR)..\src\Earmark.App\Assets\AppIcon.ico" />
     <Property Id="ARPPRODUCTICON" Value="EarmarkIcon" />
     <Property Id="ARPHELPLINK" Value="https://github.com/hoobio/earmark" />
     <Property Id="ARPURLINFOABOUT" Value="https://github.com/hoobio/earmark" />

--- a/installer/Earmark.wxs
+++ b/installer/Earmark.wxs
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Earmark MSI installer (WiX 5).
+
+  Per-user install: no UAC prompt, no Program Files writes. Earmark is a tray app
+  that lives entirely in the user session, so requiring elevation just to drop a
+  self-contained payload into LocalAppData adds friction without security value.
+
+  Preprocessor variables supplied by the build pipeline:
+    Version    - four-part version (X.Y.Z.W). Sourced from version.txt.
+    Platform   - "x64" or "ARM64". Used only for the Manufacturer arch suffix in
+                 ARP and the file payload root name; the wix `-arch` flag drives
+                 the actual MSI Template summary attribute.
+    PayloadDir - root of the published self-contained build to wrap.
+
+  UpgradeCode is stable across versions and architectures so an x64-installed
+  Earmark is correctly upgraded by a newer x64 MSI. ARM64 ships under a separate
+  UpgradeCode because Windows blocks cross-arch upgrades on per-user MSIs.
+  ProductCode is regenerated per build (default `*`).
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <?if $(var.Platform) = "ARM64" ?>
+    <?define UpgradeCodeGuid = "9F3A1E8B-2C7D-4A41-B6E5-1D8F0C9A7B22" ?>
+    <?define ShortcutGuid = "C13B7AE6-4F2E-4B0A-A4D7-7E8C1A5B9D31" ?>
+    <?define PlatformLabel = "ARM64" ?>
+  <?else?>
+    <?define UpgradeCodeGuid = "755F033C-94B7-466F-B5FA-2BFAEADADDA0" ?>
+    <?define ShortcutGuid = "2E5E5C30-4A8E-4B1E-8E13-9D9B1B5C6F70" ?>
+    <?define PlatformLabel = "x64" ?>
+  <?endif?>
+
+  <Package
+      Name="Earmark"
+      Manufacturer="hoobio"
+      Version="$(var.Version)"
+      UpgradeCode="$(var.UpgradeCodeGuid)"
+      Scope="perUser"
+      Compressed="yes"
+      InstallerVersion="500">
+
+    <SummaryInformation Description="Earmark $(var.PlatformLabel) installer" />
+
+    <MajorUpgrade
+        DowngradeErrorMessage="A newer version of Earmark is already installed."
+        Schedule="afterInstallInitialize" />
+
+    <Media Id="1" Cabinet="Earmark.cab" EmbedCab="yes" CompressionLevel="high" />
+
+    <Icon Id="EarmarkIcon" SourceFile="$(var.PayloadDir)\Assets\AppIcon.ico" />
+    <Property Id="ARPPRODUCTICON" Value="EarmarkIcon" />
+    <Property Id="ARPHELPLINK" Value="https://github.com/hoobio/earmark" />
+    <Property Id="ARPURLINFOABOUT" Value="https://github.com/hoobio/earmark" />
+    <Property Id="ARPNOREPAIR" Value="1" />
+    <Property Id="ARPNOMODIFY" Value="1" />
+
+    <StandardDirectory Id="LocalAppDataFolder">
+      <Directory Id="INSTALLFOLDER" Name="Earmark" />
+    </StandardDirectory>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Component Id="StartMenuShortcut" Guid="$(var.ShortcutGuid)">
+        <Shortcut Id="EarmarkShortcut"
+                  Name="Earmark"
+                  Description="Per-app audio routing"
+                  Target="[INSTALLFOLDER]Earmark.App.exe"
+                  WorkingDirectory="INSTALLFOLDER"
+                  Icon="EarmarkIcon"
+                  IconIndex="0" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\hoobio\Earmark"
+                       Name="StartMenuShortcut"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </StandardDirectory>
+
+    <Feature Id="Main" Title="Earmark" Level="1" AllowAdvertise="no" Display="expand" ConfigurableDirectory="INSTALLFOLDER">
+      <ComponentGroupRef Id="EarmarkPayload" />
+      <ComponentRef Id="StartMenuShortcut" />
+    </Feature>
+
+  </Package>
+
+  <Fragment>
+    <ComponentGroup Id="EarmarkPayload" Directory="INSTALLFOLDER">
+      <Files Include="$(var.PayloadDir)\**" />
+    </ComponentGroup>
+  </Fragment>
+
+</Wix>

--- a/installer/Earmark.wxs
+++ b/installer/Earmark.wxs
@@ -66,7 +66,11 @@
     <Property Id="ARPHELPLINK" Value="https://github.com/hoobio/earmark" />
     <Property Id="ARPURLINFOABOUT" Value="https://github.com/hoobio/earmark" />
     <Property Id="ARPNOREPAIR" Value="1" />
-    <Property Id="ARPNOMODIFY" Value="1" />
+    <!--
+      ARPNOMODIFY is set automatically by the WixUI_InstallDir dialog set, so
+      declaring it here would be a duplicate-symbol error.
+    -->
+
 
     <StandardDirectory Id="LocalAppDataFolder">
       <Directory Id="INSTALLFOLDER" Name="Earmark" />
@@ -106,7 +110,11 @@
       `NOT Installed` condition restricts it to first-time installs (not repair
       / uninstall flows).
     -->
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+    <!--
+      WIXUI_INSTALLDIR is set automatically by `<ui:WixUI ... InstallDirectory="INSTALLFOLDER" />`,
+      so a manual <Property> declaration here would conflict with the value the
+      extension's dialog set already publishes.
+    -->
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch Earmark" />
     <Property Id="WixShellExecTarget" Value="[#EarmarkAppExe]" />

--- a/installer/Earmark.wxs
+++ b/installer/Earmark.wxs
@@ -114,8 +114,7 @@
     <CustomAction Id="LaunchApplication"
                   BinaryRef="Wix4UtilCA_X86"
                   DllEntry="WixShellExec"
-                  Impersonate="yes"
-                  Return="asyncNoWait" />
+                  Impersonate="yes" />
 
     <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
     <WixVariable Id="WixUILicenseRtf" Value="$(sys.SOURCEFILEDIR)License.rtf" />
@@ -141,7 +140,7 @@
               Source="$(var.PayloadDir)\Earmark.App.exe"
               KeyPath="yes" />
       </Component>
-      <Files Include="$(var.PayloadDir)\**" Subdirectory=".">
+      <Files Include="$(var.PayloadDir)\**">
         <Exclude Files="$(var.PayloadDir)\Earmark.App.exe" />
       </Files>
     </ComponentGroup>

--- a/installer/Earmark.wxs
+++ b/installer/Earmark.wxs
@@ -6,19 +6,26 @@
   that lives entirely in the user session, so requiring elevation just to drop a
   self-contained payload into LocalAppData adds friction without security value.
 
+  UI flow uses WixUI_InstallDir (Welcome -> License -> InstallDir -> Verify ->
+  Progress -> Finish) so the user gets visible feedback during install, can
+  customise the install location, and can opt to launch Earmark when the
+  installer finishes.
+
   Preprocessor variables supplied by the build pipeline:
     Version    - four-part version (X.Y.Z.W). Sourced from version.txt.
-    Platform   - "x64" or "ARM64". Used only for the Manufacturer arch suffix in
-                 ARP and the file payload root name; the wix `-arch` flag drives
-                 the actual MSI Template summary attribute.
+    Platform   - "x64" or "ARM64". Used to namespace the per-arch UpgradeCode and
+                 Component GUIDs. The wix `-arch` flag drives the actual MSI
+                 Template summary attribute.
     PayloadDir - root of the published self-contained build to wrap.
 
-  UpgradeCode is stable across versions and architectures so an x64-installed
-  Earmark is correctly upgraded by a newer x64 MSI. ARM64 ships under a separate
-  UpgradeCode because Windows blocks cross-arch upgrades on per-user MSIs.
-  ProductCode is regenerated per build (default `*`).
+  UpgradeCode is stable per-architecture so a newer x64 MSI correctly upgrades an
+  installed x64 Earmark. ARM64 ships under a separate UpgradeCode because Windows
+  blocks cross-arch upgrades on per-user MSIs. ProductCode is regenerated per
+  build (default `*`).
 -->
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <?if $(var.Platform) = "ARM64" ?>
     <?define UpgradeCodeGuid = "9F3A1E8B-2C7D-4A41-B6E5-1D8F0C9A7B22" ?>
@@ -88,11 +95,55 @@
       <ComponentRef Id="StartMenuShortcut" />
     </Feature>
 
+    <!--
+      WixUI_InstallDir provides the configurable install path dialog. The Finish
+      dialog gets a "Launch Earmark" optional checkbox bound to a WixShellExec
+      custom action so the user can start the app from the installer.
+
+      WIXUI_INSTALLDIR points the InstallDir dialog at our INSTALLFOLDER property
+      so the Browse button writes back to the right place. The Publish element
+      wires the Finish button's checkbox state to the launch custom action; the
+      `NOT Installed` condition restricts it to first-time installs (not repair
+      / uninstall flows).
+    -->
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch Earmark" />
+    <Property Id="WixShellExecTarget" Value="[#EarmarkAppExe]" />
+
+    <CustomAction Id="LaunchApplication"
+                  BinaryRef="Wix4UtilCA_X86"
+                  DllEntry="WixShellExec"
+                  Impersonate="yes"
+                  Return="asyncNoWait" />
+
+    <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
+    <WixVariable Id="WixUILicenseRtf" Value="$(sys.SOURCEFILEDIR)License.rtf" />
+
+    <UI>
+      <Publish Dialog="ExitDialog"
+               Control="Finish"
+               Event="DoAction"
+               Value="LaunchApplication"
+               Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed" />
+    </UI>
+
   </Package>
 
+  <!--
+    Payload harvest. Earmark.App.exe gets an explicit File Id so WixShellExec can
+    target it via [#EarmarkAppExe]; everything else is auto-harvested by <Files>.
+  -->
   <Fragment>
     <ComponentGroup Id="EarmarkPayload" Directory="INSTALLFOLDER">
-      <Files Include="$(var.PayloadDir)\**" />
+      <Component Id="EarmarkAppExeComponent" Guid="0E9B8C61-9F47-4D1F-94E6-7A2C3D5F4B82">
+        <File Id="EarmarkAppExe"
+              Source="$(var.PayloadDir)\Earmark.App.exe"
+              KeyPath="yes" />
+      </Component>
+      <Files Include="$(var.PayloadDir)\**" Subdirectory=".">
+        <Exclude Files="$(var.PayloadDir)\Earmark.App.exe" />
+      </Files>
     </ComponentGroup>
   </Fragment>
 

--- a/installer/License.rtf
+++ b/installer/License.rtf
@@ -1,0 +1,11 @@
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+\viewkind4\uc1\pard\sa120\sl276\slmult1\f0\fs20\lang9
+\b MIT License\b0\par
+Copyright (c) 2026 Hoobi\par
+\par
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
+\par
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
+\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
+}


### PR DESCRIPTION
## Summary

Adds an MSI build path for enterprise / IT distribution where MSIX isn't acceptable. Each release will now ship both MSIX and MSI artefacts on the GitHub Release page alongside the existing SBOM.

- `installer/Earmark.wxs`: per-user (HKCU, no UAC) install of the unpackaged self-contained build under `%LocalAppData%\Earmark`, with a Start-menu shortcut and ARP entry. Stable per-arch `UpgradeCode`; `ProductCode` auto-regenerates per build.
- `.github/workflows/build.yaml`: new `build-msi` matrix job (x64 + ARM64) that publishes the self-contained payload, calls `build-msi-wix` and `sign-msi` composite actions from `hoobio/pipeline-tools`, and uploads each `.msi` as an artefact. The `release` job now downloads, attests, and attaches both MSIX and MSI assets to the draft release before flipping it to published.

The pipeline-tools pin is currently a feature-branch SHA (`d48c7263c2bc532fd2ddf3e3a8a20e6f1f38e77b` from `feat/wix-msi-helpers`). Once that PR is merged and a tagged release is cut, the pins in this PR will be bumped to the tag in a follow-up commit before merge.

## Test plan

- [ ] CI workflow run is fully green for x64 and ARM64
- [ ] `build-msi` produces `Earmark-<version>-<platform>.msi` for each platform
- [ ] Sign step is gated on `HAS_SIGNING_CERT` (matches `build-msix` pattern)
- [ ] Release job downloads MSI artefacts and attaches them to the draft release alongside MSIX + SBOM
- [ ] Local install of an unsigned MSI produces a working tray app under `%LocalAppData%\Earmark` with a Start-menu shortcut