### PR TITLE
fix(ui): tray context menu and installer icon publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - id: rp
-        uses: hoobio/pipeline-tools/pipeline/github/step/release-please@v1.3.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/release-please@549437dcf6f20cd8d064eedc5780687ead9ac8a7
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
           app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - id: rp
-        uses: hoobio/pipeline-tools/pipeline/github/step/release-please@549437dcf6f20cd8d064eedc5780687ead9ac8a7
+        uses: hoobio/pipeline-tools/pipeline/github/step/release-please@v1.3.1
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
           app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}

--- a/src/Earmark.App/Earmark.App.csproj
+++ b/src/Earmark.App/Earmark.App.csproj
@@ -29,7 +29,13 @@
     <Content Include="Assets\Square44x44Logo.scale-200.png" />
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
-    <Content Include="Assets\AppIcon.ico" />
+    <!--
+      AppIcon.ico is loaded at runtime from AppContext.BaseDirectory by the tray
+      icon code. WinUI defaults Content to publish-but-not-build, and the unpackaged
+      publish output (used by the MSI) doesn't carry it across, so be explicit
+      about both copies. Other PNG assets only matter for MSIX so leave them alone.
+    -->
+    <Content Include="Assets\AppIcon.ico" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="Assets\logo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
   </ItemGroup>

--- a/src/Earmark.App/Services/WindowChromeManager.cs
+++ b/src/Earmark.App/Services/WindowChromeManager.cs
@@ -152,14 +152,21 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
 
         icon.LeftClickCommand = new RelayCommandSimple(_ => RestoreWindow());
 
+        // H.NotifyIcon's default ContextMenuMode (PopupMenu, native Win32) wires
+        // native item clicks to MenuFlyoutItem.Command only - Click events are
+        // never raised. Bind Command, not Click.
         var menu = new Microsoft.UI.Xaml.Controls.MenuFlyout();
-        var showItem = new Microsoft.UI.Xaml.Controls.MenuFlyoutItem { Text = "Open Earmark" };
-        showItem.Click += (_, _) => RestoreWindow();
-        menu.Items.Add(showItem);
+        menu.Items.Add(new Microsoft.UI.Xaml.Controls.MenuFlyoutItem
+        {
+            Text = "Open Earmark",
+            Command = new RelayCommandSimple(_ => RestoreWindow()),
+        });
         menu.Items.Add(new Microsoft.UI.Xaml.Controls.MenuFlyoutSeparator());
-        var exitItem = new Microsoft.UI.Xaml.Controls.MenuFlyoutItem { Text = "Quit" };
-        exitItem.Click += (_, _) => RequestExit();
-        menu.Items.Add(exitItem);
+        menu.Items.Add(new Microsoft.UI.Xaml.Controls.MenuFlyoutItem
+        {
+            Text = "Quit",
+            Command = new RelayCommandSimple(_ => RequestExit()),
+        });
         icon.ContextFlyout = menu;
 
         icon.ForceCreate();


### PR DESCRIPTION
## Summary

Two product fixes plus the release-please pipeline-tools pin bump:

- **Tray context menu** (`fix(ui)`): the Open / Quit items did nothing. H.NotifyIcon's default ContextMenuMode is the native Win32 `PopupMenu`, which only invokes `MenuFlyoutItem.Command` - the `Click` event is never raised. Bind `RelayCommandSimple` via `Command` on each item.
- **Installer icon** (`fix(installer)`): WinUI defaults Content items to publish-but-not-build. The unpackaged self-contained publish output (the MSI's PayloadDir) wasn't carrying `AppIcon.ico` across, so the runtime tray icon load against `AppContext.BaseDirectory` was missing the file. Set `CopyToOutputDirectory` + `CopyToPublishDirectory` explicitly on the icon Content item.
- **release-please pin** (`ci`): bump the release-please composite-action pin to `v1.3.1`. That release adds a pre-tag step that fixes the duplicate-next-release PR ([googleapis/release-please#1650](https://github.com/googleapis/release-please/issues/1650)). After merge, release-please should produce a clean v0.1.2 PR with only these fixes (no re-listed v0.1.1 commits) and not open a follow-up duplicate v0.1.3.

## Test plan

- [x] Build, MSIX/MSI, WACK, SBOM all green on x64 + ARM64
- [x] After merge: release-please opens v0.1.2 PR with only the two `fix:` entries
- [x] After merging the v0.1.2 release PR: no duplicate v0.1.3 PR opens
- [x] v0.1.2 release page has 7 raw assets attached and `isDraft: false`

fix(installer): copy AppIcon.ico to publish output for the MSI
ci: pin release-please to v1.3.1