### PR TITLE
fix(shutdown): prevent process hang and slow startup

### DIFF
--- a/src/Earmark.App/App.xaml.cs
+++ b/src/Earmark.App/App.xaml.cs
@@ -5,6 +5,7 @@ using Earmark.App.ViewModels;
 using Earmark.App.Views;
 using Earmark.Audio;
 using Earmark.Core;
+using Earmark.Core.Audio;
 using Earmark.Core.Services;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -53,14 +54,31 @@ public partial class App : Application
             _host.Services.GetRequiredService<StartupSettingsApplier>().Start();
             _logger.LogInformation("Settings loaded");
 
-            await _host.Services.GetRequiredService<IRulesService>().LoadAsync();
-            _logger.LogInformation("Rules loaded");
+            // Heavy init (audio endpoint + session enumeration via COM, rules load, routing
+            // applier startup) runs on the thread pool so the UI thread can paint immediately.
+            // MainWindow.InitializationTask gates the first page navigation - RulesViewModel
+            // depends on the audio singletons, so navigating before this task completes would
+            // force their construction synchronously on the UI thread, which is what we just
+            // moved off it.
+            var initTask = Task.Run(async () =>
+            {
+                _ = _host.Services.GetRequiredService<IAudioSessionService>();
+                _logger.LogInformation("Audio services initialized");
 
-            _host.Services.GetRequiredService<IRoutingApplier>().Start();
-            _logger.LogInformation("Routing applier started");
+                await _host.Services.GetRequiredService<IRulesService>().LoadAsync();
+                _logger.LogInformation("Rules loaded");
+
+                _host.Services.GetRequiredService<IRoutingApplier>().Start();
+                _logger.LogInformation("Routing applier started");
+            });
 
             _window = _host.Services.GetRequiredService<MainWindow>();
-            _window.Closed += async (_, _) => await DisposeHostAsync();
+            _window.InitializationTask = initTask;
+            // Sync handler on purpose: WinUI stops pumping the dispatcher once the last
+            // window closes, so an `async void` continuation containing _host.Dispose()
+            // can be dropped on the floor and leak COM resources / the IMMNotificationClient
+            // registration, which manifests as the process hanging after close.
+            _window.Closed += (_, _) => DisposeHost();
 
             var chrome = _host.Services.GetRequiredService<IWindowChromeManager>();
             chrome.Attach(_window);
@@ -78,6 +96,10 @@ public partial class App : Application
                 _window.Activate();
                 _logger.LogInformation("Main window activated");
             }
+
+            _ = initTask.ContinueWith(
+                t => _logger.LogError(t.Exception, "Background startup failed"),
+                TaskContinuationOptions.OnlyOnFaulted);
         }
         catch (Exception ex)
         {
@@ -97,26 +119,35 @@ public partial class App : Application
         chrome?.RestoreWindow();
     }
 
-    private async Task DisposeHostAsync()
+    public void DisposeHost()
     {
         if (_host is null)
         {
             return;
         }
 
+        var host = _host;
+        _host = null;
+
         _logger?.LogInformation("Shutting down host");
 
         try
         {
-            await _host.StopAsync(TimeSpan.FromSeconds(2));
+            host.StopAsync(TimeSpan.FromSeconds(2)).GetAwaiter().GetResult();
         }
         catch
         {
             // Ignore shutdown failures.
         }
 
-        _host.Dispose();
-        _host = null;
+        try
+        {
+            host.Dispose();
+        }
+        catch
+        {
+            // Ignore disposal failures.
+        }
     }
 
     private void OnUnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/src/Earmark.App/MainWindow.xaml.cs
+++ b/src/Earmark.App/MainWindow.xaml.cs
@@ -25,13 +25,31 @@ public sealed partial class MainWindow : Window
         _dispatcher.Register(DispatcherQueue);
         _navigation.Register(ContentFrame);
 
-        NavView.Loaded += (_, _) =>
+        NavView.Loaded += async (_, _) =>
         {
+            // Wait for background init (audio service construction, rules load) before the
+            // first navigation. RulesViewModel depends on the audio singletons; navigating
+            // before they're ready would resolve them on the UI thread and freeze startup.
+            if (InitializationTask is { } init)
+            {
+                try
+                {
+                    await init;
+                }
+                catch
+                {
+                    // Failures are already logged by App.OnLaunched; navigate anyway so the
+                    // user sees a (degraded) UI rather than a blank window.
+                }
+            }
+
             var first = (NavigationViewItem)NavView.MenuItems[0];
             NavigateTo(first);
             NavView.SelectedItem = first;
         };
     }
+
+    public Task? InitializationTask { get; set; }
 
     private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {

--- a/src/Earmark.App/Services/WindowChromeManager.cs
+++ b/src/Earmark.App/Services/WindowChromeManager.cs
@@ -86,7 +86,12 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
         _exitRequested = true;
         _trayIcon?.Dispose();
         _trayIcon = null;
+
+        // Window.Close() fires Window.Closed synchronously, which runs App.DisposeHost()
+        // and tears down COM. Belt-and-suspenders: also call DisposeHost directly in case
+        // the close path is ever changed to be async.
         _window?.Close();
+        (Microsoft.UI.Xaml.Application.Current as App)?.DisposeHost();
         Microsoft.UI.Xaml.Application.Current.Exit();
     }
 

--- a/src/Earmark.Audio/Services/AudioEndpointService.cs
+++ b/src/Earmark.Audio/Services/AudioEndpointService.cs
@@ -19,6 +19,7 @@ public sealed class AudioEndpointService : IAudioEndpointService, IMMNotificatio
     private readonly MMDeviceEnumerator _enumerator;
     private readonly Lock _rebuildGate = new();
     private readonly Timer _safetyTimer;
+    private readonly CancellationTokenSource _shutdownCts = new();
 
     private Snapshot _snapshot = Snapshot.Empty;
     private bool _registered;
@@ -152,17 +153,43 @@ public sealed class AudioEndpointService : IAudioEndpointService, IMMNotificatio
 
     private void OnSafetyTick(object? state) => TryRebuild();
 
-    private void RaiseEndpointsChanged()
-    {
-        TryRebuild();
-        EndpointsChanged?.Invoke(this, EventArgs.Empty);
-    }
+    // IMMNotificationClient callbacks fire on a COM thread that the OS will block during
+    // UnregisterEndpointNotificationCallback if any handler is in flight. Doing the rebuild
+    // synchronously here (which itself enumerates COM endpoints and fans out to subscribers
+    // that re-enumerate again) opens a window where a hardware change racing with shutdown
+    // deadlocks the unregister call. Pushing the work onto the thread pool keeps the COM
+    // callback fast and avoids that race.
+    private void RaiseEndpointsChanged() => QueueRebuild(raiseDefaults: false);
 
-    private void RaiseDefaultsAndEndpointsChanged()
+    private void RaiseDefaultsAndEndpointsChanged() => QueueRebuild(raiseDefaults: true);
+
+    private void QueueRebuild(bool raiseDefaults)
     {
-        TryRebuild();
-        EndpointsChanged?.Invoke(this, EventArgs.Empty);
-        DefaultsChanged?.Invoke(this, EventArgs.Empty);
+        if (_disposed)
+        {
+            return;
+        }
+
+        var token = _shutdownCts.Token;
+        _ = Task.Run(() =>
+        {
+            if (token.IsCancellationRequested || _disposed)
+            {
+                return;
+            }
+
+            TryRebuild();
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            EndpointsChanged?.Invoke(this, EventArgs.Empty);
+            if (raiseDefaults)
+            {
+                DefaultsChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }, token);
     }
 
     void IMMNotificationClient.OnDeviceStateChanged(string deviceId, DeviceState newState) => RaiseEndpointsChanged();
@@ -179,6 +206,18 @@ public sealed class AudioEndpointService : IAudioEndpointService, IMMNotificatio
         }
 
         _disposed = true;
+
+        // Cancel any queued rebuilds before unregistering so callbacks already on the
+        // thread pool short-circuit instead of touching disposed COM state.
+        try
+        {
+            _shutdownCts.Cancel();
+        }
+        catch
+        {
+            // Ignore.
+        }
+
         _safetyTimer.Dispose();
 
         if (_registered)
@@ -196,6 +235,7 @@ public sealed class AudioEndpointService : IAudioEndpointService, IMMNotificatio
         }
 
         _enumerator.Dispose();
+        _shutdownCts.Dispose();
     }
 
     private sealed record Snapshot(


### PR DESCRIPTION
## Summary

Two related correctness/perf fixes around the app lifecycle: window activation no longer waits on COM enumeration, and clean exit no longer leaks the host on the way out.

## Changes

- **Startup** (`App.OnLaunched`, `MainWindow`): the `IAudioEndpointService` / `IAudioSessionService` constructors enumerate Render + Capture endpoints in `DeviceState.All` and attach a session watcher per device, which used to run synchronously on the UI thread (~4-5s here). Moved that work plus rules load and applier start into a `Task.Run`, and gated `MainWindow`'s first navigation on it so `RulesViewModel` does not pull the singletons back onto the UI thread when it constructs.
- **Shutdown** (`App`, `WindowChromeManager`, `AudioEndpointService`): three races could leave the process running indefinitely after close - documented in the second commit message. Fix them by making host disposal synchronous and bounded, calling it explicitly before `Application.Current.Exit()`, and pushing `IMMNotificationClient` rebuilds onto the thread pool so `UnregisterEndpointNotificationCallback` does not deadlock against an in-flight COM callback.

## Testing

- [x] Manual testing on a Windows 11 host (build 26200): cold launch with `LaunchToTray=true` shows window-activated log line at ~0.7s vs ~5s previously, and the audio init lines fire ~4s later from the thread pool.
- [x] Tail of latest log shows `Applied rule ...` lines after init completes, dedupe `Skip` lines on subsequent timer ticks.
- [ ] No unit tests added (no Core-level changes).
- [x] Existing build clean (`dotnet build src/Earmark.App/Earmark.App.csproj -c Debug -p:Platform=x64`).

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings
- [x] No emoji / gitmoji
- [x] Architecture boundaries respected (App-only changes plus a focused Audio change for the COM callback race)
- [ ] CLAUDE.md / README / CONTRIBUTING - no behavior or schema change worth documenting

perf(startup): defer audio init and rules load off the UI thread