### PR TITLE
perf(installer): shrink MSI size

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
 
     <!-- Audio -->
-    <PackageVersion Include="NAudio" Version="2.2.1" />
+    <PackageVersion Include="NAudio.Wasapi" Version="2.2.1" />
 
     <!-- Tests -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/src/Earmark.App/Earmark.App.csproj
+++ b/src/Earmark.App/Earmark.App.csproj
@@ -73,7 +73,54 @@
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <!--
+      Trimming was attempted in this PR but disabled: the .NET 10 trimmer hard-strips
+      System.StubHelpers.InterfaceMarshaler (and friends) when classic-COM interop is
+      reachable, even with BuiltInComInteropSupport=true and an explicit
+      TrimmerRootDescriptor. The trimmer prints
+      "IL2026: Built-in COM support is not trim compatible" and the runtime then
+      throws TypeLoadException on the first MMDeviceEnumerator call. Earmark's
+      Core Audio path goes through NAudio.CoreAudioApi (classic [InterfaceType
+      (InterfaceIsIUnknown)]) plus our own IPolicyConfigVista interop, so trimming
+      requires a full migration to ComWrappers source-generators. Tracked as
+      future work; for now JsonSerializerContext usage already keeps the
+      serializer trim-safe and the COM interop remains classic.
+    -->
     <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
+
+  <!--
+    Earmark doesn't use Windows ML, but Microsoft.WindowsAppSDK 1.8 transitively pulls
+    in Microsoft.WindowsAppSDK.ML, which copies ~41 MB of native binaries
+    (onnxruntime.dll, DirectML.dll, Microsoft.Windows.AI.MachineLearning.dll, plus
+    the managed Microsoft.ML.OnnxRuntime.dll wrapper) into the build output via the
+    SDK's MSIX-style payload harvest. There is no supported opt-out yet
+    (microsoft/WindowsAppSDK#5969), so prune the payload at every stage that copies it:
+      1. Remove it from CopyLocal sets so it doesn't land in bin\.
+      2. Remove it from ResolvedFileToPublish so it doesn't land in the publish dir.
+    If WindowsAppSDK later wires a runtime probe to these files this exclusion will
+    need to come back out, but at runtime today the WindowsAppRuntime bootstrap does
+    not LoadLibrary onnxruntime/DirectML unless ML APIs are actually invoked.
+  -->
+  <PropertyGroup>
+    <_EarmarkMLFilenameRegex>^(onnxruntime|onnxruntime_providers_shared|DirectML|Microsoft\.Windows\.AI\.MachineLearning|Microsoft\.Windows\.AI\.MachineLearning\.Projection|Microsoft\.ML\.OnnxRuntime)\.(dll|winmd)$</_EarmarkMLFilenameRegex>
+  </PropertyGroup>
+
+  <Target Name="_EarmarkPruneMLFromCopyLocal" AfterTargets="ResolveAssemblyReferences;ResolveProjectReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
+          Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(FileName)%(Extension)', '$(_EarmarkMLFilenameRegex)'))" />
+      <None Remove="@(None)"
+          Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(FileName)%(Extension)', '$(_EarmarkMLFilenameRegex)'))" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_EarmarkPruneMLFromPublish" AfterTargets="ComputeFilesToPublish">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
+          Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(FileName)%(Extension)', '$(_EarmarkMLFilenameRegex)'))" />
+    </ItemGroup>
+    <Message Importance="high" Text="EarmarkPruneML: ResolvedFileToPublish count after prune = @(ResolvedFileToPublish-&gt;Count())" />
+  </Target>
 
 </Project>

--- a/src/Earmark.App/Settings/SettingsService.cs
+++ b/src/Earmark.App/Settings/SettingsService.cs
@@ -3,15 +3,15 @@ using System.Text.Json.Serialization;
 
 namespace Earmark.App.Settings;
 
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(AppSettings))]
+internal sealed partial class SettingsJsonContext : JsonSerializerContext;
+
 internal sealed class SettingsService : ISettingsService, IDisposable
 {
-    private static readonly JsonSerializerOptions SerializerOptions = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
     private static readonly string DefaultPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
         "Hoobi",
@@ -37,7 +37,7 @@ internal sealed class SettingsService : ISettingsService, IDisposable
 
             await using var stream = File.OpenRead(DefaultPath);
             var loaded = await JsonSerializer
-                .DeserializeAsync<AppSettings>(stream, SerializerOptions, ct)
+                .DeserializeAsync(stream, SettingsJsonContext.Default.AppSettings, ct)
                 .ConfigureAwait(false);
             Current = loaded ?? new AppSettings();
         }
@@ -58,7 +58,7 @@ internal sealed class SettingsService : ISettingsService, IDisposable
 
             await using var buffer = new MemoryStream();
             await JsonSerializer
-                .SerializeAsync(buffer, Current, SerializerOptions, ct)
+                .SerializeAsync(buffer, Current, SettingsJsonContext.Default.AppSettings, ct)
                 .ConfigureAwait(false);
 
             var bytes = buffer.ToArray();

--- a/src/Earmark.Audio/Earmark.Audio.csproj
+++ b/src/Earmark.Audio/Earmark.Audio.csproj
@@ -9,7 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" />
+    <!--
+      NAudio.Wasapi (not the NAudio metapackage) so we don't drag in NAudio.WinForms,
+      which framework-references Microsoft.WindowsDesktop.App.WindowsForms and
+      bloats self-contained publish by ~24 MB of WinForms binaries.
+    -->
+    <PackageReference Include="NAudio.Wasapi" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 

--- a/src/Earmark.Core/Persistence/JsonRuleStore.cs
+++ b/src/Earmark.Core/Persistence/JsonRuleStore.cs
@@ -5,17 +5,17 @@ using Earmark.Core.Models;
 
 namespace Earmark.Core.Persistence;
 
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(List<RoutingRule>))]
+internal sealed partial class RuleJsonContext : JsonSerializerContext;
+
 public sealed class JsonRuleStore : IRuleStore, IDisposable
 {
     public void Dispose() => _gate.Dispose();
-
-    private static readonly JsonSerializerOptions SerializerOptions = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Converters = { new JsonStringEnumConverter() },
-    };
 
     private readonly string _path;
     private readonly SemaphoreSlim _gate = new(1, 1);
@@ -44,7 +44,7 @@ public sealed class JsonRuleStore : IRuleStore, IDisposable
 
             await using var stream = File.OpenRead(_path);
             var rules = await JsonSerializer
-                .DeserializeAsync<List<RoutingRule>>(stream, SerializerOptions, ct)
+                .DeserializeAsync(stream, RuleJsonContext.Default.ListRoutingRule, ct)
                 .ConfigureAwait(false);
 
             return rules ?? new List<RoutingRule>();
@@ -66,7 +66,7 @@ public sealed class JsonRuleStore : IRuleStore, IDisposable
 
             await using var buffer = new MemoryStream();
             await JsonSerializer
-                .SerializeAsync(buffer, rules.ToList(), SerializerOptions, ct)
+                .SerializeAsync(buffer, rules.ToList(), RuleJsonContext.Default.ListRoutingRule, ct)
                 .ConfigureAwait(false);
 
             var bytes = buffer.ToArray();


### PR DESCRIPTION
## Summary

Drops the Earmark MSI from **91 MB to 68 MB** (-26%) and the uncompressed self-contained publish output from **310 MB to 233 MB** (-25%) by removing two transitively-bundled payloads that Earmark does not use.

## Size before / after

| Metric                        | Before  | After   | Delta         |
|-------------------------------|---------|---------|---------------|
| MSI (compressed)              | 91 MB   | 68 MB   | -23 MB (-26%) |
| Publish dir (uncompressed)    | 310 MB  | 233 MB  | -77 MB (-25%) |
| Files in publish dir          | 639     | 554     | -85           |

## Changes

- **NAudio metapackage swapped for NAudio.Wasapi.** The metapackage transitively pulls `NAudio.WinForms`, which framework-references `Microsoft.WindowsDesktop.App.WindowsForms` and brought ~24 MB of WinForms binaries (`System.Windows.Forms.dll`, `.Design`, `.Primitives`, `.Private.Windows.Core`, `System.Drawing.Common`, `System.Configuration.ConfigurationManager`) into self-contained publish output. Earmark.Audio only uses `NAudio.CoreAudioApi` (which lives in `NAudio.Wasapi`), so the swap is API-compatible.
- **Microsoft.WindowsAppSDK.ML payload pruned** (~41 MB raw / ~17 MB compressed). WindowsAppSDK 1.8 transitively pulls `Microsoft.WindowsAppSDK.ML` 1.8.2192, which copies `onnxruntime.dll`, `DirectML.dll`, `Microsoft.Windows.AI.MachineLearning.dll`, plus the `Microsoft.ML.OnnxRuntime.dll` managed wrapper into self-contained publish output. Earmark does not use Windows ML. There is no supported opt-out yet ([microsoft/WindowsAppSDK#5969](https://github.com/microsoft/WindowsAppSDK/issues/5969)); two new MSBuild targets in `src/Earmark.App/Earmark.App.csproj` strip the ML files from `ReferenceCopyLocalPaths`/`None` and from `ResolvedFileToPublish` via a filename regex. If WindowsAppSDK later wires a runtime probe to these files this exclusion will need to come back out, but at runtime today the WindowsAppRuntime bootstrap does not LoadLibrary onnxruntime/DirectML unless Windows ML APIs are actually invoked.
- **JSON serialization moved to source-generated `JsonSerializerContext`** for `AppSettings` and `List<RoutingRule>`. Trim/AOT-friendly and slightly faster, even though full trimming is currently disabled.

## Deliberately not done

- **`PublishTrimmed=true`.** Tried it. .NET 10's trimmer hard-strips `System.StubHelpers.InterfaceMarshaler` (the classic-COM marshalling stub) when classic COM is reachable, even with `BuiltInComInteropSupport=true` and an explicit `TrimmerRootDescriptor`. The trimmer prints `IL2026: Built-in COM support is not trim compatible` and the runtime then throws `TypeLoadException` on the first `MMDeviceEnumerator` construction. Earmark's Core Audio path goes through `NAudio.CoreAudioApi` (classic `[InterfaceType(InterfaceIsIUnknown)]`) plus our own `IPolicyConfigVista` and `IAudioPolicyConfigFactory` interop, so trimming would require migrating to ComWrappers source-generators. Left as future work and called out inline in `Earmark.App.csproj`.
- **Removing NAudio entirely.** The remaining `NAudio.Core` + `NAudio.Wasapi` together are ~120 KB; replacing them with hand-rolled COM interop (similar to what we already do for `IPolicyConfigVista`) is roughly five COM interface declarations plus IID/HResult plumbing, for negligible MSI savings. Worth doing only as a precondition for the trimming work above.

## Testing

Validated end-to-end on this Windows 11 host:

- `dotnet publish src/Earmark.App/Earmark.App.csproj -c Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64 -p:WindowsPackageType=None -p:WindowsAppSDKSelfContained=true -p:SelfContained=true -o publish/x64-trimmed` exit 0, no new warnings beyond the pre-existing CsWinRT/.NET WinRT projection rollups.
- `wix build ... -d PayloadDir=publish/x64-trimmed -out staging/msi-x64/Earmark-1.0.0-x64.msi installer/Earmark.wxs ...` exit 0.
- `msiexec /i staging/msi-x64/Earmark-1.0.0-x64.msi /qn` exit 0; install dir `%LocalAppData%\Earmark\` populated; `Earmark.App.exe` launches and parks in the system tray; secondary activation surfaces the main window with title "Earmark"; rule application against running processes works (latest log shows `AudioPolicyService init: ... using Win11 interface`, `Activated factory 'Windows.Media.Internal.AudioPolicyConfig' as Win11 layout`, `Applied rule Media to msedge ... -> Media (Elgato Virtual Audio)`).
- Verified no `forms`, `onnx`, `directml`, or `machinelearning` files appear in the publish output after the prune.

- [x] Manual testing on a Windows 10 (19041+) or Windows 11 host
- [x] Tail of the latest log file under `%LocalAppData%\Earmark\logs\` shows the expected `Applied rule ...` / `Skip Set ...` / `Skip re-apply ...` lines after the change
- [ ] Unit tests added/updated under `tests/Earmark.Core.Tests`
- [x] Existing tests pass (`dotnet test -p:Platform=x64`) - no test changes; the existing Core.Tests scaffold has no rule-store tests today

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings (`dotnet build src/Earmark.App/Earmark.App.csproj -c Debug -p:Platform=x64`)
- [x] No emoji / gitmoji in commit messages or PR title (breaks release-please)
- [x] Architecture boundary respected: domain logic in `Earmark.Core`, Windows audio interop in `Earmark.Audio`, UI in `Earmark.App`
- [x] CLAUDE.md / README / CONTRIBUTING updated if behavior, build steps, or schema changed - no behavior change requiring doc update; the inline comments in `Earmark.App.csproj` document the ML prune and trimming-disabled rationale