### PR TITLE
fix(audio): release COM wrappers and adopt singleton view-model lifetime

### DIFF
--- a/src/Earmark.App/Hosting/HostBuilderExtensions.cs
+++ b/src/Earmark.App/Hosting/HostBuilderExtensions.cs
@@ -47,13 +47,13 @@ internal static class HostBuilderExtensions
 
         builder.Services.AddSingleton<MainWindow>();
         builder.Services.AddSingleton<ShellViewModel>();
-        builder.Services.AddTransient<RulesViewModel>();
-        builder.Services.AddTransient<SessionsViewModel>();
-        builder.Services.AddTransient<SettingsViewModel>();
+        builder.Services.AddSingleton<RulesViewModel>();
+        builder.Services.AddSingleton<SessionsViewModel>();
+        builder.Services.AddSingleton<SettingsViewModel>();
 
-        builder.Services.AddTransient<RulesPage>();
-        builder.Services.AddTransient<SessionsPage>();
-        builder.Services.AddTransient<SettingsPage>();
+        builder.Services.AddSingleton<RulesPage>();
+        builder.Services.AddSingleton<SessionsPage>();
+        builder.Services.AddSingleton<SettingsPage>();
 
         return builder;
     }

--- a/src/Earmark.Audio/Services/AudioEndpointService.cs
+++ b/src/Earmark.Audio/Services/AudioEndpointService.cs
@@ -188,6 +188,10 @@ public sealed class AudioEndpointService : IAudioEndpointService, IMMNotificatio
             {
                 _logger.LogWarning(ex, "Failed to map endpoint {Id}", device.ID);
             }
+            finally
+            {
+                device.Dispose();
+            }
         }
 
         return list;

--- a/src/Earmark.Audio/Services/AudioSessionService.cs
+++ b/src/Earmark.Audio/Services/AudioSessionService.cs
@@ -112,15 +112,26 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
                 for (var i = 0; i < sessions.Count; i++)
                 {
                     var session = sessions[i];
-                    if (TryMap(session, device.ID, out var mapped))
+                    try
                     {
-                        results.Add(mapped);
+                        if (TryMap(session, device.ID, out var mapped))
+                        {
+                            results.Add(mapped);
+                        }
+                    }
+                    finally
+                    {
+                        session.Dispose();
                     }
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Enumerating sessions on {Id} failed", device.ID);
+            }
+            finally
+            {
+                device.Dispose();
             }
         }
 
@@ -142,14 +153,23 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
 
             foreach (var device in _enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active))
             {
+                var attached = false;
                 try
                 {
                     var watcher = new SessionWatcher(device, this);
                     _watchers[device.ID] = watcher;
+                    attached = true;
                 }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Failed to attach session watcher to {Id}", device.ID);
+                }
+                finally
+                {
+                    if (!attached)
+                    {
+                        device.Dispose();
+                    }
                 }
             }
         }
@@ -264,8 +284,10 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
         private readonly MMDevice _device;
         private readonly AudioSessionService _owner;
         private readonly NotificationClient _notify;
+        private readonly System.Collections.Concurrent.ConcurrentBag<AudioSessionControl> _registeredControls = new();
 
         private readonly string _deviceId;
+        private bool _disposed;
 
         public SessionWatcher(MMDevice device, AudioSessionService owner)
         {
@@ -280,10 +302,16 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
 
         private void OnSessionCreated(object sender, IAudioSessionControl newSession)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             try
             {
                 var control = new AudioSessionControl(newSession);
                 control.RegisterEventClient(this);
+                _registeredControls.Add(control);
                 if (_owner.TryMap(control, _deviceId, out var mapped))
                 {
                     _owner._logger.LogInformation(
@@ -310,6 +338,13 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
 
         public void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
             try
             {
                 _device.AudioSessionManager.OnSessionCreated -= OnSessionCreated;
@@ -317,6 +352,12 @@ public sealed class AudioSessionService : IAudioSessionService, IDisposable
             catch
             {
                 // Ignore.
+            }
+
+            while (_registeredControls.TryTake(out var control))
+            {
+                try { control.UnRegisterEventClient(this); } catch { }
+                try { control.Dispose(); } catch { }
             }
 
             _device.Dispose();


### PR DESCRIPTION
## Summary

Fixes a runaway thread/memory leak that grew to ~32k threads and ~4 GB private bytes over an 11-hour session. Three coupled causes, all addressed:

- **`AudioSessionService.BuildSnapshot`** leaked an `MMDevice` and an `AudioSessionControl` per audio session per call. Both now disposed in `finally` blocks.
- **`SessionWatcher.OnSessionCreated`** registered an `IAudioSessionEvents` sink on each new session and never unregistered it. Sinks are now tracked in a `ConcurrentBag` and unregistered + disposed on watcher disposal, with a `_disposed` guard so a late COM callback no-ops instead of registering against a dying watcher.
- **`AudioEndpointService.BuildList`** had the same `MMDevice` non-disposal pattern. Same `finally`-block fix.
- **`HostBuilderExtensions`** registered the three view models and their pages as `Transient`. Direct `Frame.Content` navigation never disposed them, so each page switch leaked a VM that stayed subscribed to audio events forever. Switched to `Singleton`: one instance per type for the app lifetime, disposed via the host on shutdown. As a side benefit, page state is preserved across navigation.

## Test plan

- [x] Builds clean (0 warnings, 0 errors).
- [x] Manual: launched fresh, baseline ~108 threads / ~190 MB.
- [x] Manual: rapid Sessions <-> Rules switching no longer grows memory (was +160 MB in 4 minutes pre-fix; flat after fix).
- [ ] Overnight soak: leave running 8+ hours and confirm thread count stays under ~200 and working set under ~300 MB. (Pre-fix this was the path to 32k threads.)

fix(audio): release MMDevice / AudioSessionControl wrappers and unregister event sinks
fix(app): use singleton lifetime for pages and view models so navigation does not leak VMs