### PR TITLE
docs(release-please): require blank lines between footer entries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,9 +26,16 @@
 - [ ] CLAUDE.md / README / CONTRIBUTING updated if behavior, build steps, or schema changed
 
 <!-- If this PR contains multiple logical changes for the changelog, add
-     additional conventional commit footers below. See CLAUDE.md for details.
+     additional conventional commit footers below, separated by blank
+     lines. See AGENTS.md "Multi-change PRs" for the full rules.
 
-     Example:
+     Blank lines between footers are REQUIRED - release-please's parser
+     groups consecutive non-blank lines into one paragraph and only
+     picks up the first conventional-commit line per paragraph.
+
+     ---
+
      fix(routing): clear dedupe cache on rule change
+
      test: cover RuleEvaluator shadow logic
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,23 +176,32 @@ Update
 
 ### Multi-change PRs (PR description format)
 
-This repo uses **squash merges**, so the PR description body becomes the commit message that release-please parses. To produce multiple changelog entries from a single PR, append additional conventional-commit footers at the **bottom** of the PR description body:
+This repo uses **squash merges**, so the PR description body becomes the commit message that release-please parses. To produce multiple changelog entries from a single PR, append additional conventional-commit footers at the **bottom** of the PR description body, **each separated by a blank line**:
 
 ```
 feat: add per-app input routing
 
 Optional body text explaining the PR.
 
+---
+
+<!-- release-please footers: one bare conventional-commit line per
+extra change, separated by blank lines. -->
+
 fix(audio): release COM factory on shutdown
-BREAKING-CHANGE: rename ApplicationOutput field "Priority" to "Order"
+
 test: cover the new RuleEvaluator shadow logic
+
+BREAKING-CHANGE: rename ApplicationOutput field "Priority" to "Order"
 ```
 
-- Each footer entry must follow the same `type(scope): description` format
-- `BREAKING-CHANGE:` (or `BREAKING CHANGE:`) triggers a MAJOR bump
-- Additional entries must appear **after** any free-form body text, not between paragraphs
-- Only `feat`, `fix`, `perf`, and `revert` produce changelog entries; `ci`, `test`, `docs`, `chore`, `build`, `style`, `refactor` do not
-- Each entry produces its own changelog line
+- **Blank line between every footer is required.** release-please's parser groups consecutive non-blank lines into a single paragraph and only treats the first conventional-commit line in each paragraph as an entry. Stacked footers without blank lines produce exactly one extra changelog line (the first), and the rest are silently dropped (this is what bit PR #32).
+- Soft-wrapping the description text *within* a single footer is fine (e.g. GitHub auto-wraps at ~80 chars when you save the PR description). The parser walks the whole paragraph for the conventional-commit prefix - just don't introduce a blank line mid-footer.
+- Each footer must follow the same `type(scope): description` format.
+- `BREAKING-CHANGE:` (or `BREAKING CHANGE:`) triggers a MAJOR bump. Place it as its own blank-line-separated footer.
+- Additional entries must appear **after** any free-form body text, not between paragraphs.
+- Every type produces a changelog entry (`release-please-config.json` sets `hidden: false` for all sections). Only `feat`, `fix`, `perf`, `revert`, and any footer with a breaking-change marker trigger a version bump; `chore` / `docs` / `style` / `refactor` / `test` / `build` / `ci` add a line under their section without bumping the version.
+- Each footer produces its own changelog line.
 
 ### Repo CI plumbing
 


### PR DESCRIPTION
## Summary

Updates AGENTS.md "Multi-change PRs" section and `.github/pull_request_template.md` to specify that conventional-commit footers in a squash-merge PR description body must be **blank-line-separated**. This is what was missing on PR #32 (`7ea82f9`) which only produced one changelog entry out of the eight intended.

## Why

release-please's parser groups consecutive non-blank lines into a single paragraph and only treats the first conventional-commit line per paragraph as a changelog entry. The old guidance and PR template hint both showed footers stacked without blank lines, which is why PR #32's `feat(audio):`, `feat(home)` x2, `feat(ui):`, `fix(rules):`, `perf(audio):`, and `chore:` footers were silently dropped. Cross-checked against command-palette-bitwarden squash commits (e.g. `60e48c7`) which work because each footer is blank-line-separated.

## Changes

- **AGENTS.md** "Multi-change PRs":
  - Example uses blank-line-separated footers (matching the layout release-please actually parses).
  - Explicit rule and reason for the blank line requirement.
  - Note that soft-wrapping within a single footer is fine.
  - Correct the old "only feat/fix/perf/revert produce changelog entries" bullet: every type produces an entry because `release-please-config.json` sets `hidden: false` on all sections; only the version-bump effect differs.
- **`.github/pull_request_template.md`**: hint updated with the same convention, pointer changed from CLAUDE.md to AGENTS.md.

## Already done

The bad PR #32 squash commit message has been amended on main and force-pushed (with the `main` ruleset briefly disabled and re-enabled) so release-please will pick up the missed entries on its next run. See open PR #29 once it refreshes.

## Testing

- [x] Local diff review against the working command-palette-bitwarden footer format
- [ ] Wait for release-please workflow to re-run after this merges and confirm PR #29 lists the additional `feat(audio)`, `feat(home)`, `feat(ui)`, `perf(audio)`, `chore` entries