### PR TITLE
feat: hide app chips via a context menu, manage from settings

### DIFF
--- a/src/Earmark.App/Settings/AppSettings.cs
+++ b/src/Earmark.App/Settings/AppSettings.cs
@@ -112,10 +112,36 @@ public sealed class AppSettings
     /// </summary>
     public List<DeviceGroup> DeviceGroups { get; set; } = new();
 
+    /// <summary>
+    /// Apps the user has permanently hidden from the device cards' app-indicator rows, via a chip's
+    /// "Hide this app" context menu. Hidden everywhere (on every device card), keyed by the app's
+    /// <see cref="Earmark.Core.Models.AudioSession.IdentityKey"/> (lower-cased executable path, or
+    /// process name when the path is unavailable). The app still routes / plays normally; only its
+    /// chip is suppressed. Managed (unhidden) from Settings &gt; App indicators.
+    /// </summary>
+    public List<HiddenApp> HiddenApps { get; set; } = new();
+
     /// <summary>Persisted window size in physical pixels. Null until the user has resized
     /// at least once (so first launch picks the WinUI default).</summary>
     public int? WindowWidth { get; set; }
     public int? WindowHeight { get; set; }
+}
+
+/// <summary>
+/// One app the user has hidden from the Devices-page chip rows. <see cref="Key"/> is the match
+/// target (an <see cref="Earmark.Core.Models.AudioSession.IdentityKey"/>); <see cref="Name"/> is the
+/// friendly label captured when it was hidden, so the manage list reads "Discord" rather than a raw
+/// path even when the app isn't currently running.
+/// </summary>
+public sealed class HiddenApp
+{
+    /// <summary>Match key: the app's <see cref="Earmark.Core.Models.AudioSession.IdentityKey"/>
+    /// (lower-cased executable path, or process name when no path is available).</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>Friendly display name captured at hide time. Null falls back to a name derived from
+    /// <see cref="Key"/>.</summary>
+    public string? Name { get; set; }
 }
 
 /// <summary>

--- a/src/Earmark.App/ViewModels/AppChip.cs
+++ b/src/Earmark.App/ViewModels/AppChip.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 using Earmark.App.Services;
 using Earmark.Core.Audio;
@@ -76,13 +77,17 @@ public partial class AppChip : ObservableObject
         return true;
     }
 
-    public AppChip(AudioSession session, string placementEndpointId, ISessionIconService iconService, PeakMeterOptions meterOptions, RoutingRule? lockingRule, bool startsActive = true)
+    private readonly Action<AppChip>? _onHide;
+
+    public AppChip(AudioSession session, string placementEndpointId, ISessionIconService iconService, PeakMeterOptions meterOptions, RoutingRule? lockingRule, bool startsActive = true, DeviceCard? ownerCard = null, Action<AppChip>? onHide = null)
     {
         Session = session ?? throw new ArgumentNullException(nameof(session));
         PlacementEndpointId = placementEndpointId ?? throw new ArgumentNullException(nameof(placementEndpointId));
         _iconService = iconService ?? throw new ArgumentNullException(nameof(iconService));
         MeterOptions = meterOptions ?? throw new ArgumentNullException(nameof(meterOptions));
         LockingRule = lockingRule;
+        OwnerCard = ownerCard;
+        _onHide = onHide;
         // An audible chip is treated as having started its run the moment we first see it (we can't
         // know when it truly started before observing). A silent rule-pinned chip starts with both
         // timestamps null - "never produced audio" - so it sits in the back tier, dimmed, until it
@@ -164,6 +169,16 @@ public partial class AppChip : ObservableObject
     /// </summary>
     public string PlacementEndpointId { get; }
     public string SourceEndpointId => PlacementEndpointId;
+
+    /// <summary>The device card this chip lives on. Set at construction (a chip never migrates cards -
+    /// a card change spawns a fresh chip), so the chip's context menu can offer the owning card's
+    /// device / group actions alongside the app-specific "Hide this app".</summary>
+    public DeviceCard? OwnerCard { get; }
+
+    /// <summary>Permanently hides this app from every device card's chip row (it still routes and plays;
+    /// only the chip is suppressed). Persisted via <c>HomeViewModel</c>; reversible from Settings.</summary>
+    [RelayCommand]
+    private void Hide() => _onHide?.Invoke(this);
 
     public string LockTooltip
     {

--- a/src/Earmark.App/ViewModels/HomeViewModel.cs
+++ b/src/Earmark.App/ViewModels/HomeViewModel.cs
@@ -49,6 +49,10 @@ public partial class HomeViewModel : ObservableObject, IDisposable
     private WaveLinkChannelStyle? _lastAppliedStyle;
     private bool? _lastFilterForwarders;
     private bool? _lastShowAppIndicators;
+    private int? _lastHiddenAppsCount;
+    /// <summary>Identity keys of apps the user has permanently hidden from the chip rows, mirrored
+    /// from <see cref="AppSettings.HiddenApps"/> for O(1) lookups on the 20Hz tick.</summary>
+    private readonly HashSet<string> _hiddenAppKeys = new(StringComparer.OrdinalIgnoreCase);
     private readonly INotificationService _notifications;
     private readonly ILogger<HomeViewModel> _logger;
     private readonly Dictionary<string, DateTime> _lastReconcileToast = new(StringComparer.OrdinalIgnoreCase);
@@ -141,6 +145,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         // to the style field so unrelated saves (hidden/pinned devices) don't trigger work.
         _settings.SettingsChanged += OnSettingsChanged;
         SyncMeterOptions();
+        RefreshHiddenApps();
 
         IsInitializing = true;
         QueueRefresh();
@@ -341,6 +346,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
                 foreach (var session in sessionsSnapshot)
                 {
                     if (!ShouldShow(session)) continue;
+                    if (IsAppHidden(session.IdentityKey)) continue;
                     if (seenAppsOnThisCard.Contains(session.IdentityKey)) continue;
 
                     var livePeak = _sessionMeters.GetPeak(session.ProcessId, card.Endpoint.Id) ?? 0f;
@@ -350,7 +356,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
                         .Concat(_endpoints.GetEndpoints(EndpointFlow.Capture))
                         .ToList();
                     var match = _matcher.FindAppRoute(session, EndpointFlow.Render, rulesSnapshot, combinedEndpointsCache, sessionsSnapshot);
-                    var revivedChip = new AppChip(session, card.Endpoint.Id, _iconService, _meterOptions, match?.Rule)
+                    var revivedChip = new AppChip(session, card.Endpoint.Id, _iconService, _meterOptions, match?.Rule, ownerCard: card, onHide: HideApp)
                     {
                         RulePinnedHere = match is not null &&
                             string.Equals(match.Endpoint.Id, card.Endpoint.Id, StringComparison.OrdinalIgnoreCase),
@@ -597,7 +603,13 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             // indicators are off the reconcile clears every row and the 20Hz app-meter tick is
             // skipped, idling the per-session meter service. Tracked so unrelated saves don't
             // churn the apps rows.
-            if (_settings.Current.FilterAudioForwarders != _lastFilterForwarders ||
+            // A hidden-apps add/remove (count change) is detected here too - unhiding from the
+            // Settings modal lands via this path. RefreshHiddenApps updates the count baseline so
+            // it doesn't re-trigger; the chip's own Hide path already updated it before saving.
+            var hiddenAppsChanged = _settings.Current.HiddenApps.Count != _lastHiddenAppsCount;
+            if (hiddenAppsChanged) RefreshHiddenApps();
+            if (hiddenAppsChanged ||
+                _settings.Current.FilterAudioForwarders != _lastFilterForwarders ||
                 _settings.Current.ShowAppIndicators != _lastShowAppIndicators)
             {
                 _lastFilterForwarders = _settings.Current.FilterAudioForwarders;
@@ -950,6 +962,22 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             return;
         }
 
+        // Drop any chip whose app the user has permanently hidden (the set may have grown since the
+        // chip was placed). The additions loop below skips hidden apps too, so nothing re-adds them.
+        if (_hiddenAppKeys.Count > 0)
+        {
+            var removedHidden = false;
+            for (var i = card.Apps.Count - 1; i >= 0; i--)
+            {
+                if (IsAppHidden(card.Apps[i].Session.IdentityKey))
+                {
+                    card.Apps.RemoveAt(i);
+                    removedHidden = true;
+                }
+            }
+            if (removedHidden) card.NotifyAppsChanged();
+        }
+
         // Classify + age out existing chips. An app whose identity is on no live source (no audio
         // session, no running process) has exited -> mark the chip closed (it lingers, dimmed +
         // badged). An app that's back -> revive a stale closed chip, adopting its live session.
@@ -1030,6 +1058,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             if (!ShouldShow(session)) continue;
 
             var key = session.IdentityKey;
+            if (IsAppHidden(key)) continue;
             routeByPid.TryGetValue(session.ProcessId, out var match);
             var pinnedHere = match is not null &&
                 string.Equals(match.Endpoint.Id, card.Endpoint.Id, StringComparison.OrdinalIgnoreCase);
@@ -1061,7 +1090,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         foreach (var add in additions.Values
             .OrderBy(a => a.Session.IsSystemSounds ? "System Sounds" : a.Session.DisplayName, StringComparer.OrdinalIgnoreCase))
         {
-            var chip = new AppChip(add.Session, card.Endpoint.Id, _iconService, _meterOptions, add.Rule, startsActive: add.Audible)
+            var chip = new AppChip(add.Session, card.Endpoint.Id, _iconService, _meterOptions, add.Rule, startsActive: add.Audible, ownerCard: card, onHide: HideApp)
             {
                 RulePinnedHere = add.PinnedHere,
             };
@@ -1221,6 +1250,60 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         {
             // Errors surface via the logger inside the policy service.
         }
+    }
+
+    /// <summary>Rebuilds <see cref="_hiddenAppKeys"/> from <see cref="AppSettings.HiddenApps"/> and
+    /// refreshes the count baseline used to detect changes in <see cref="OnSettingsChanged"/>.</summary>
+    private void RefreshHiddenApps()
+    {
+        _hiddenAppKeys.Clear();
+        foreach (var app in _settings.Current.HiddenApps)
+        {
+            if (!string.IsNullOrEmpty(app.Key)) _hiddenAppKeys.Add(app.Key);
+        }
+        _lastHiddenAppsCount = _settings.Current.HiddenApps.Count;
+    }
+
+    private bool IsAppHidden(string identityKey) => _hiddenAppKeys.Contains(identityKey);
+
+    /// <summary>
+    /// Permanently hides an app from every device card's chip row (the chip's "Hide this app"
+    /// context menu). Records the app's identity key + friendly name in settings, drops every chip
+    /// for it now for instant feedback, and persists. The app keeps routing / playing; only its
+    /// chip is suppressed. Reversible from Settings &gt; App indicators.
+    /// </summary>
+    public void HideApp(AppChip chip)
+    {
+        ArgumentNullException.ThrowIfNull(chip);
+        var key = chip.Session.IdentityKey;
+        if (string.IsNullOrEmpty(key)) return;
+
+        if (!_settings.Current.HiddenApps.Any(h => string.Equals(h.Key, key, StringComparison.OrdinalIgnoreCase)))
+        {
+            _settings.Current.HiddenApps.Add(new HiddenApp { Key = key, Name = chip.DisplayLabel });
+        }
+        // Update the live set + count baseline now so the 20Hz tick can't re-add the chip and our
+        // own save's SettingsChanged doesn't trigger a redundant reconcile.
+        _hiddenAppKeys.Add(key);
+        _lastHiddenAppsCount = _settings.Current.HiddenApps.Count;
+
+        // An app can be audible on more than one card; drop every chip that matches.
+        foreach (var card in _allCards)
+        {
+            var removed = false;
+            for (var i = card.Apps.Count - 1; i >= 0; i--)
+            {
+                if (string.Equals(card.Apps[i].Session.IdentityKey, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    card.Apps.RemoveAt(i);
+                    removed = true;
+                }
+            }
+            if (removed) card.NotifyAppsChanged();
+        }
+
+        _logger.LogInformation("App hidden from chip rows: key='{Key}'", key);
+        QueueSettingsSave();
     }
 
     private DeviceCard? FindCard(string endpointId) =>

--- a/src/Earmark.App/ViewModels/SettingsViewModel.cs
+++ b/src/Earmark.App/ViewModels/SettingsViewModel.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using Earmark.App.Services;
@@ -190,6 +192,67 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     /// <summary>Gates the app-indicator child settings - they only matter while the chips show.</summary>
     public bool AppIndicatorChildrenEnabled => ShowAppIndicators;
 
+    // ---- Hidden apps (chip "Hide this app" context menu) ----
+
+    /// <summary>Apps the user has permanently hidden from the device cards' chip rows. Populated by
+    /// <see cref="LoadHiddenApps"/> when the manage modal opens, and mutated by unhide / clear.</summary>
+    public ObservableCollection<HiddenAppRow> HiddenApps { get; } = new();
+
+    public bool HasHiddenApps => _settings.Current.HiddenApps.Count > 0;
+    public bool NoHiddenApps => !HasHiddenApps;
+
+    /// <summary>Card description that reflects how many apps are hidden.</summary>
+    public string HiddenAppsDescription
+    {
+        get
+        {
+            var n = _settings.Current.HiddenApps.Count;
+            return n == 0
+                ? "Apps you've hidden from the device cards with a chip's right-click menu. None hidden yet."
+                : $"{n} app{(n == 1 ? "" : "s")} hidden from the device cards. Manage to unhide.";
+        }
+    }
+
+    /// <summary>(Re)loads the manage list from settings - called when the modal opens so it reflects
+    /// hides made on the Devices page since the page was last shown.</summary>
+    public void LoadHiddenApps()
+    {
+        HiddenApps.Clear();
+        foreach (var app in _settings.Current.HiddenApps)
+        {
+            HiddenApps.Add(new HiddenAppRow(app.Key, app.Name));
+        }
+        RefreshHiddenAppsState();
+    }
+
+    /// <summary>Unhides one app: its chip can reappear on the device cards. Persists immediately;
+    /// <c>HomeViewModel</c> reconciles via the settings-changed event.</summary>
+    public void UnhideApp(HiddenAppRow row)
+    {
+        if (row is null) return;
+        HiddenApps.Remove(row);
+        Persist(s => s.HiddenApps.RemoveAll(h => string.Equals(h.Key, row.Key, StringComparison.OrdinalIgnoreCase)));
+        RefreshHiddenAppsState();
+    }
+
+    /// <summary>Unhides every app at once.</summary>
+    public void ClearAllHiddenApps()
+    {
+        if (_settings.Current.HiddenApps.Count == 0) return;
+        HiddenApps.Clear();
+        Persist(s => s.HiddenApps.Clear());
+        RefreshHiddenAppsState();
+    }
+
+    /// <summary>Refreshes the count-derived bindings. Also called by the page on navigation so the
+    /// card description tracks hides made from the Devices page.</summary>
+    public void RefreshHiddenAppsState()
+    {
+        OnPropertyChanged(nameof(HasHiddenApps));
+        OnPropertyChanged(nameof(NoHiddenApps));
+        OnPropertyChanged(nameof(HiddenAppsDescription));
+    }
+
     partial void OnAppChipLingerSecondsChanged(double value)
     {
         // NumberBox hands back NaN when cleared; ignore until it carries a real number again.
@@ -239,5 +302,40 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     public void Dispose()
     {
         _waveLink.StateChanged -= OnWaveLinkStateChanged;
+    }
+}
+
+/// <summary>A row in the "Hidden apps" manage list. <see cref="Name"/> is the friendly label (the
+/// session display name captured at hide time, falling back to the executable filename);
+/// <see cref="Detail"/> is the full identity key, shown as muted subtext when it differs.</summary>
+public sealed class HiddenAppRow
+{
+    public HiddenAppRow(string key, string? name)
+    {
+        Key = key ?? string.Empty;
+        Name = string.IsNullOrWhiteSpace(name) ? DeriveName(Key) : name!;
+    }
+
+    /// <summary>Match key (the app's identity key) used to remove the entry on unhide.</summary>
+    public string Key { get; }
+
+    public string Name { get; }
+
+    public string Detail => Key;
+
+    public bool HasDetail => !string.IsNullOrEmpty(Key) && !string.Equals(Key, Name, StringComparison.OrdinalIgnoreCase);
+
+    private static string DeriveName(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return "Unknown app";
+        try
+        {
+            var file = System.IO.Path.GetFileName(key);
+            return string.IsNullOrEmpty(file) ? key : file;
+        }
+        catch
+        {
+            return key;
+        }
     }
 }

--- a/src/Earmark.App/Views/HomePage.xaml
+++ b/src/Earmark.App/Views/HomePage.xaml
@@ -481,6 +481,59 @@
                                             DropCompleted="OnAppChipDropCompleted"
                                             AutomationProperties.Name="{x:Bind DisplayLabel, Mode=OneWay}"
                                             ToolTipService.ToolTip="{x:Bind Tooltip}">
+                                        <!-- Right-click a chip: the app-specific "Hide this app" sits ABOVE the
+                                             owning card's device / group actions (bound through OwnerCard), so a
+                                             chip's menu is a superset of the card's. The device / group block
+                                             mirrors the card's ContextFlyout above - keep the two in sync. -->
+                                        <Border.ContextFlyout>
+                                            <MenuFlyout>
+                                                <MenuFlyoutItem Text="Hide this app"
+                                                                Command="{x:Bind HideCommand}"
+                                                                ToolTipService.ToolTip="Permanently hide this app's chip from every device. Unhide it from Settings &#x2192; App indicators.">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xED1A;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutSeparator />
+                                                <MenuFlyoutItem Text="{x:Bind OwnerCard.HideToggleTooltip, Mode=OneWay}"
+                                                                Command="{x:Bind OwnerCard.ToggleUserVisibilityCommand}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="{x:Bind OwnerCard.HideToggleGlyph, Mode=OneWay}" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem Text="{x:Bind OwnerCard.VolumeControlsToggleLabel, Mode=OneWay}"
+                                                                Command="{x:Bind OwnerCard.ToggleVolumeControlsCommand}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="{x:Bind OwnerCard.VolumeControlsToggleGlyph, Mode=OneWay}" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutSeparator Visibility="{x:Bind OwnerCard.IsGroupMember, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                <MenuFlyoutItem Text="Rename group"
+                                                                Click="OnRenameGroupClicked"
+                                                                Tag="{x:Bind OwnerCard}"
+                                                                Visibility="{x:Bind OwnerCard.IsGroupMember, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE8AC;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem Text="Ungroup device"
+                                                                Click="OnUngroupDeviceClicked"
+                                                                Tag="{x:Bind OwnerCard}"
+                                                                Visibility="{x:Bind OwnerCard.IsGroupMember, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xF0B4;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem Text="Ungroup all"
+                                                                Click="OnUngroupAllClicked"
+                                                                Tag="{x:Bind OwnerCard}"
+                                                                Visibility="{x:Bind OwnerCard.IsGroupMember, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xF0B4;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                            </MenuFlyout>
+                                        </Border.ContextFlyout>
                                         <!-- Dim lives on this inner Grid, not the Border / container: the
                                              theme transitions drive the container's Opacity/Offset on
                                              add/remove/reorder, so binding the dim here keeps the idle /

--- a/src/Earmark.App/Views/SettingsPage.xaml
+++ b/src/Earmark.App/Views/SettingsPage.xaml
@@ -8,6 +8,32 @@
     xmlns:ui="using:Windows.UI"
     Background="Transparent">
 
+    <Page.Resources>
+        <!-- One row in the hidden-apps manage modal: friendly name + (muted) identity path + Unhide. -->
+        <DataTemplate x:Key="HiddenAppRowTemplate" x:DataType="vm:HiddenAppRow">
+            <Grid ColumnSpacing="{StaticResource SpacingMedium}" Padding="0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="{StaticResource SpacingXXSmall}">
+                    <TextBlock Text="{x:Bind Name}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" />
+                    <TextBlock Text="{x:Bind Detail}"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                               TextTrimming="CharacterEllipsis"
+                               TextWrapping="NoWrap"
+                               Visibility="{x:Bind HasDetail, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </StackPanel>
+                <Button Grid.Column="1"
+                        Content="Unhide"
+                        Click="OnUnhideApp"
+                        Tag="{x:Bind}"
+                        VerticalAlignment="Center" />
+            </Grid>
+        </DataTemplate>
+    </Page.Resources>
+
     <Grid Padding="{StaticResource PagePadding}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -67,6 +93,14 @@
                                        SpinButtonPlacementMode="Inline"
                                        SmallChange="5" LargeChange="30"
                                        MinWidth="140" />
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Hidden apps"
+                                           Description="{x:Bind ViewModel.HiddenAppsDescription, Mode=OneWay}"
+                                           IsEnabled="{x:Bind ViewModel.AppIndicatorChildrenEnabled, Mode=OneWay}">
+                            <ctrl:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="&#xED1A;" />
+                            </ctrl:SettingsCard.HeaderIcon>
+                            <Button Content="Manage" Click="OnManageHiddenApps" />
                         </ctrl:SettingsCard>
                     </ctrl:SettingsExpander.Items>
                 </ctrl:SettingsExpander>
@@ -273,5 +307,50 @@
 
             </StackPanel>
         </ScrollViewer>
+
+        <!-- Hidden-apps manage modal. Lives in the visual tree (not Page.Resources) so its x:Binds
+             compile; ContentDialog renders nothing until ShowAsync, so it claims no layout. -->
+        <ContentDialog x:Name="HiddenAppsDialog"
+                       Grid.RowSpan="2"
+                       Title="Hidden apps"
+                       CloseButtonText="Done"
+                       DefaultButton="Close">
+            <Grid MinWidth="380" RowSpacing="{StaticResource SpacingMedium}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0"
+                           Text="These apps don't show a chip on any device. Unhide one to bring its chip back."
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           TextWrapping="Wrap" />
+                <TextBlock Grid.Row="1"
+                           Text="No apps are hidden."
+                           Style="{StaticResource MutedCaptionTextStyle}"
+                           Margin="0,4,0,0"
+                           Visibility="{x:Bind ViewModel.NoHiddenApps, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                <ListView Grid.Row="1"
+                          ItemsSource="{x:Bind ViewModel.HiddenApps, Mode=OneWay}"
+                          ItemTemplate="{StaticResource HiddenAppRowTemplate}"
+                          SelectionMode="None"
+                          MaxHeight="320"
+                          Visibility="{x:Bind ViewModel.HasHiddenApps, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="Padding" Value="0" />
+                            <Setter Property="MinHeight" Value="0" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                </ListView>
+                <Button Grid.Row="2"
+                        Content="Clear all"
+                        Click="OnClearAllHiddenApps"
+                        HorizontalAlignment="Right"
+                        Visibility="{x:Bind ViewModel.HasHiddenApps, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            </Grid>
+        </ContentDialog>
     </Grid>
 </Page>

--- a/src/Earmark.App/Views/SettingsPage.xaml.cs
+++ b/src/Earmark.App/Views/SettingsPage.xaml.cs
@@ -30,6 +30,10 @@ public sealed partial class SettingsPage : Page
         About = about;
         MeterSwatches = BuildMeterSwatches();
         InitializeComponent();
+
+        // The hidden-apps count can change from the Devices page while this singleton page is
+        // off-screen, so refresh its card description each time the page is shown.
+        Loaded += (_, _) => ViewModel.RefreshHiddenAppsState();
     }
 
     public SettingsViewModel ViewModel { get; }
@@ -67,4 +71,21 @@ public sealed partial class SettingsPage : Page
     private void OnOpenGitHub(object sender, RoutedEventArgs e) => About.OpenGitHub();
 
     private void OnOpenLogsFolder(object sender, RoutedEventArgs e) => About.OpenLogsFolder();
+
+    private async void OnManageHiddenApps(object sender, RoutedEventArgs e)
+    {
+        ViewModel.LoadHiddenApps();
+        HiddenAppsDialog.XamlRoot = XamlRoot;
+        await HiddenAppsDialog.ShowAsync();
+    }
+
+    private void OnUnhideApp(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { Tag: HiddenAppRow row })
+        {
+            ViewModel.UnhideApp(row);
+        }
+    }
+
+    private void OnClearAllHiddenApps(object sender, RoutedEventArgs e) => ViewModel.ClearAllHiddenApps();
 }


### PR DESCRIPTION
Adds a "Hide this app" item to each app chip's right-click menu on the Devices page, shown above the existing device / group actions (so a chip's menu is a superset of the card's). Hiding suppresses that app's chip on every device card, matched by executable path; the app still routes and plays normally.

Hidden apps are managed from **Settings > App indicators > Hidden apps**: a Manage button opens a modal listing each hidden app (name + path) with per-app Unhide and a Clear all.

## Implementation
- `AppSettings.HiddenApps`: global list of `{ Key, Name }`, keyed by the session `IdentityKey` (lower-cased exe path, process-name fallback).
- `HomeViewModel` mirrors the set into `_hiddenAppKeys` and filters it in the chip reconcile and the 20Hz placement pass. `HideApp` drops the chip from every card instantly and persists; unhides flow back via the settings-changed event.
- `AppChip` gains `OwnerCard` plus a `Hide` command, so the chip's context menu can offer the app action alongside the owning card's device / group actions.

## Verification
- Built x64 and ran the app. Filter confirmed end-to-end: a seeded hidden entry suppressed the chip, and removing it brought the chip back. Context menu and manage modal click-tested in the running app.
- Rebased onto current main (includes #39 backdrop setting) and rebuilt clean (0 warnings).
