### PR TITLE
feat: add Devices-page reset to default and new-install seeding

### DIFF
--- a/src/Earmark.App/App.xaml.cs
+++ b/src/Earmark.App/App.xaml.cs
@@ -81,6 +81,12 @@ public partial class App : Application
                 await _host.Services.GetRequiredService<IRulesService>().LoadAsync();
                 _logger.LogInformation("Rules loaded");
 
+                // Blank-slate installs only: seed the starter device groups + two disabled example
+                // rules. A no-op when any rule or Devices-page config already exists, so it never
+                // wipes an existing layout. Wave Link groups seed only if Wave Link is already
+                // connected (off by default on a fresh install).
+                await _host.Services.GetRequiredService<IDeviceDefaultsService>().SeedDefaultsIfEmptyAsync();
+
                 _host.Services.GetRequiredService<IRoutingApplier>().Start();
                 _logger.LogInformation("Routing applier started");
             });

--- a/src/Earmark.App/Hosting/HostBuilderExtensions.cs
+++ b/src/Earmark.App/Hosting/HostBuilderExtensions.cs
@@ -49,6 +49,7 @@ internal static class HostBuilderExtensions
         builder.Services.AddSingleton<ISessionIconService, SessionIconService>();
         builder.Services.AddSingleton<IWaveLinkNameReconciler, WaveLinkNameReconciler>();
         builder.Services.AddSingleton<IWaveLinkVisualService, WaveLinkVisualService>();
+        builder.Services.AddSingleton<IDeviceDefaultsService, DeviceDefaultsService>();
         builder.Services.AddSingleton<StartupSettingsApplier>();
 
         builder.Services.AddSingleton<MainWindow>();

--- a/src/Earmark.App/Services/DeviceDefaultsService.cs
+++ b/src/Earmark.App/Services/DeviceDefaultsService.cs
@@ -1,0 +1,240 @@
+using System.Text.RegularExpressions;
+
+using Earmark.App.Settings;
+using Earmark.Core.Audio;
+using Earmark.Core.Models;
+using Earmark.Core.Services;
+using Earmark.Core.WaveLink;
+
+using Microsoft.Extensions.Logging;
+
+namespace Earmark.App.Services;
+
+/// <inheritdoc cref="IDeviceDefaultsService"/>
+public sealed class DeviceDefaultsService : IDeviceDefaultsService
+{
+    private const string DefaultDevicesGroupTitle = "Default Devices";
+    private const string WaveLinkChannelsGroupTitle = "Wave Link Channels";
+
+    private const string DefaultVolumesRuleName = "Set default volumes";
+    private const string AppOutputRuleName = "Set output device for app";
+
+    // Covers new + classic Teams, Discord stable/Canary/PTB, and Slack. Matched case-insensitively
+    // against both the process name and the full executable path.
+    private const string AppOutputAppPattern = @"(ms-teams|Teams|[Dd]iscord(Canary|PTB)?|slack)\.exe";
+    private const string AppOutputDevicePattern = "Comm";
+
+    private readonly ISettingsService _settings;
+    private readonly IAudioEndpointService _endpoints;
+    private readonly IWaveLinkService _waveLink;
+    private readonly IRulesService _rules;
+    private readonly ILogger<DeviceDefaultsService> _logger;
+
+    public DeviceDefaultsService(
+        ISettingsService settings,
+        IAudioEndpointService endpoints,
+        IWaveLinkService waveLink,
+        IRulesService rules,
+        ILogger<DeviceDefaultsService> logger)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _endpoints = endpoints ?? throw new ArgumentNullException(nameof(endpoints));
+        _waveLink = waveLink ?? throw new ArgumentNullException(nameof(waveLink));
+        _rules = rules ?? throw new ArgumentNullException(nameof(rules));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public event EventHandler? DefaultsApplied;
+
+    public async Task SeedDefaultsIfEmptyAsync(CancellationToken ct = default)
+    {
+        // Seed only a blank-slate install. Any existing rule or Devices-page customisation means the
+        // user (or a prior version) already configured Earmark, so seeding - which clears the
+        // Devices-page state - would silently wipe their layout. Emptiness is the whole signal; no
+        // persisted flag needed, and an existing install can never be mistaken for a fresh one.
+        if (HasExistingConfig())
+        {
+            _logger.LogInformation("Existing config present; skipping new-install seeding");
+            return;
+        }
+
+        _logger.LogInformation("Empty config; seeding new-install defaults");
+        var defaultDevices = ApplyDefaultDeviceLayout();
+        await SeedExampleRulesAsync(defaultDevices, ct).ConfigureAwait(false);
+        await SaveAndNotifyAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>True when the install already carries user state - any rule, or any Devices-page
+    /// customisation (groups, manual order, or per-device config).</summary>
+    private bool HasExistingConfig()
+    {
+        var s = _settings.Current;
+        return _rules.Rules.Count > 0
+            || s.DeviceGroups.Count > 0
+            || s.DeviceOrder.Count > 0
+            || s.Devices.Count > 0;
+    }
+
+    public async Task ResetDeviceLayoutAsync(CancellationToken ct = default)
+    {
+        _logger.LogInformation("Resetting Devices page to defaults");
+        ApplyDefaultDeviceLayout();
+        await SaveAndNotifyAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Clears the Devices-page state (per-device config, groups, block order) and rebuilds the two
+    /// starter groups, pinning their members visible and floating them to the top of the block order.
+    /// Returns the default-device endpoints (render + capture, default + communications) so the
+    /// first-run seeder can build the example volume rule against them.
+    /// </summary>
+    private List<AudioEndpoint> ApplyDefaultDeviceLayout()
+    {
+        var s = _settings.Current;
+        s.Devices.Clear();
+        s.DeviceGroups.Clear();
+        s.DeviceOrder.Clear();
+
+        var render = _endpoints.GetEndpoints(EndpointFlow.Render).Where(e => e.State == EndpointState.Active).ToList();
+        var capture = _endpoints.GetEndpoints(EndpointFlow.Capture).Where(e => e.State == EndpointState.Active).ToList();
+        var combined = render.Concat(capture).ToList();
+        var snapshot = _waveLink.LastSnapshot;
+
+        // ---- Group 0: Default Devices (system default/communications render + capture, + first WL mix) ----
+        var defaultDevices = new List<AudioEndpoint>();
+        AddIfMissing(defaultDevices, render.FirstOrDefault(e => e.IsDefault));
+        AddIfMissing(defaultDevices, render.FirstOrDefault(e => e.IsDefaultCommunications));
+        AddIfMissing(defaultDevices, capture.FirstOrDefault(e => e.IsDefault));
+        AddIfMissing(defaultDevices, capture.FirstOrDefault(e => e.IsDefaultCommunications));
+
+        var group0Members = defaultDevices.Select(e => e.Id).ToList();
+
+        var mixEndpointId = FindFirstMixEndpointId(snapshot, combined);
+        if (mixEndpointId is not null &&
+            !group0Members.Contains(mixEndpointId, StringComparer.OrdinalIgnoreCase))
+        {
+            group0Members.Add(mixEndpointId);
+        }
+
+        var orderHead = new List<string>();
+        AddGroup(s, orderHead, DefaultDevicesGroupTitle, group0Members);
+        PinAll(s, group0Members);
+
+        // ---- Group 1: Wave Link channels (render/output-only virtual channels), minus group 0 ----
+        var channelMap = WaveLinkChannelMap.Build(snapshot, combined);
+        var group0Set = new HashSet<string>(group0Members, StringComparer.OrdinalIgnoreCase);
+        var group1Members = render
+            .Where(e => channelMap.ContainsKey(e.Id) && !group0Set.Contains(e.Id))
+            .Select(e => e.Id)
+            .ToList();
+        AddGroup(s, orderHead, WaveLinkChannelsGroupTitle, group1Members);
+        PinAll(s, group1Members);
+
+        // Groups lead the block order; every other (lone) card slots into its default-sort position
+        // below via HomeViewModel.ApplyManualBlockOrder. Non-grouped, no-rule, non-default devices
+        // auto-hide on the next rebuild (DeviceCard.IsEffectivelyHidden) - the default-hidden logic.
+        s.DeviceOrder = orderHead;
+
+        _logger.LogInformation(
+            "Default layout: {DefaultCount} default devices, {ChannelCount} Wave Link channels (WL snapshot {WlState})",
+            group0Members.Count, group1Members.Count, snapshot is null ? "absent" : "present");
+
+        return defaultDevices;
+    }
+
+    /// <summary>The render endpoint backing the first Wave Link mix (e.g. "Headphone Mix"), or null
+    /// when Wave Link isn't connected or no mix maps to a present endpoint.</summary>
+    private static string? FindFirstMixEndpointId(WaveLinkSnapshot? snapshot, IReadOnlyList<AudioEndpoint> combined)
+    {
+        if (snapshot is null) return null;
+        var mixMap = WaveLinkChannelMap.BuildMixMap(snapshot, combined);
+        foreach (var mix in snapshot.Mixes)
+        {
+            foreach (var pair in mixMap)
+            {
+                if (string.Equals(pair.Value.Id, mix.Id, StringComparison.Ordinal)) return pair.Key;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>Adds a group for <paramref name="memberIds"/> (>=2 members) and pushes its id onto the
+    /// block-order head. Fewer than two members can't render as a group, so it's skipped (members are
+    /// still pinned separately).</summary>
+    private static void AddGroup(AppSettings s, List<string> orderHead, string title, List<string> memberIds)
+    {
+        if (memberIds.Count < 2) return;
+        var group = new DeviceGroup
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Title = title,
+            MemberIds = memberIds,
+        };
+        s.DeviceGroups.Add(group);
+        orderHead.Add(group.Id);
+    }
+
+    private static void PinAll(AppSettings s, IEnumerable<string> ids)
+    {
+        foreach (var id in ids)
+        {
+            s.Devices[id] = new DeviceConfig { Pinned = true };
+        }
+    }
+
+    private static void AddIfMissing(List<AudioEndpoint> list, AudioEndpoint? endpoint)
+    {
+        if (endpoint is null) return;
+        if (list.Any(e => string.Equals(e.Id, endpoint.Id, StringComparison.OrdinalIgnoreCase))) return;
+        list.Add(endpoint);
+    }
+
+    /// <summary>Seeds the two disabled example rules on first run. Idempotent by rule name, so a
+    /// re-seed (e.g. after a crash between the rules save and the settings save) never duplicates.</summary>
+    private async Task SeedExampleRulesAsync(List<AudioEndpoint> defaultDevices, CancellationToken ct)
+    {
+        if (defaultDevices.Count > 0 && !RuleNameExists(DefaultVolumesRuleName))
+        {
+            var volumeRule = new RoutingRule
+            {
+                Name = DefaultVolumesRuleName,
+                Enabled = false,
+                Actions = defaultDevices.Select(e => new RuleAction
+                {
+                    Type = ActionType.SetDeviceVolume,
+                    DevicePattern = $"^{Regex.Escape(e.FriendlyName)}$",
+                    Volume = 1f,
+                }).ToList(),
+            };
+            await _rules.UpsertAsync(volumeRule, ct).ConfigureAwait(false);
+        }
+
+        if (!RuleNameExists(AppOutputRuleName))
+        {
+            var appRule = new RoutingRule
+            {
+                Name = AppOutputRuleName,
+                Enabled = false,
+                Actions =
+                {
+                    new RuleAction
+                    {
+                        Type = ActionType.SetApplicationOutput,
+                        AppPattern = AppOutputAppPattern,
+                        DevicePattern = AppOutputDevicePattern,
+                    },
+                },
+            };
+            await _rules.UpsertAsync(appRule, ct).ConfigureAwait(false);
+        }
+    }
+
+    private bool RuleNameExists(string name) =>
+        _rules.Rules.Any(r => string.Equals(r.Name, name, StringComparison.OrdinalIgnoreCase));
+
+    private async Task SaveAndNotifyAsync(CancellationToken ct)
+    {
+        await _settings.SaveAsync(ct).ConfigureAwait(false);
+        DefaultsApplied?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/Earmark.App/Services/DeviceDefaultsService.cs
+++ b/src/Earmark.App/Services/DeviceDefaultsService.cs
@@ -65,14 +65,15 @@ public sealed class DeviceDefaultsService : IDeviceDefaultsService
     }
 
     /// <summary>True when the install already carries user state - any rule, or any Devices-page
-    /// customisation (groups, manual order, or per-device config).</summary>
+    /// customisation (groups, manual order, per-device config, or hidden app chips).</summary>
     private bool HasExistingConfig()
     {
         var s = _settings.Current;
         return _rules.Rules.Count > 0
             || s.DeviceGroups.Count > 0
             || s.DeviceOrder.Count > 0
-            || s.Devices.Count > 0;
+            || s.Devices.Count > 0
+            || s.HiddenApps.Count > 0;
     }
 
     public async Task ResetDeviceLayoutAsync(CancellationToken ct = default)
@@ -83,8 +84,8 @@ public sealed class DeviceDefaultsService : IDeviceDefaultsService
     }
 
     /// <summary>
-    /// Clears the Devices-page state (per-device config, groups, block order) and rebuilds the two
-    /// starter groups, pinning their members visible and floating them to the top of the block order.
+    /// Clears the Devices-page state (per-device config, groups, block order, hidden app chips) and
+    /// rebuilds the two starter groups, pinning their members visible and floating them to the top.
     /// Returns the default-device endpoints (render + capture, default + communications) so the
     /// first-run seeder can build the example volume rule against them.
     /// </summary>
@@ -94,6 +95,7 @@ public sealed class DeviceDefaultsService : IDeviceDefaultsService
         s.Devices.Clear();
         s.DeviceGroups.Clear();
         s.DeviceOrder.Clear();
+        s.HiddenApps.Clear();
 
         var render = _endpoints.GetEndpoints(EndpointFlow.Render).Where(e => e.State == EndpointState.Active).ToList();
         var capture = _endpoints.GetEndpoints(EndpointFlow.Capture).Where(e => e.State == EndpointState.Active).ToList();

--- a/src/Earmark.App/Services/IDeviceDefaultsService.cs
+++ b/src/Earmark.App/Services/IDeviceDefaultsService.cs
@@ -1,0 +1,25 @@
+namespace Earmark.App.Services;
+
+/// <summary>
+/// Owns the Devices-page "defaults": the starter groups + visibility seeded on a fresh install, and
+/// the user-invoked reset that restores them. Mutates the shared <see cref="Settings.AppSettings"/>
+/// in place and raises <see cref="DefaultsApplied"/> so the Devices page rebuilds.
+/// </summary>
+public interface IDeviceDefaultsService
+{
+    /// <summary>
+    /// Seeds the starter device groups + two disabled example rules when the install is a blank slate
+    /// (no rules and no Devices-page customisation). A no-op for any configured install, so it can
+    /// never wipe an existing layout. No persisted "seeded" flag - emptiness is the signal.
+    /// </summary>
+    Task SeedDefaultsIfEmptyAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Restores the Devices page to its default groups, block order, and visibility. Never touches
+    /// rules or any non-Devices setting (theme, tray, peak meter, Wave Link, window size).
+    /// </summary>
+    Task ResetDeviceLayoutAsync(CancellationToken ct = default);
+
+    /// <summary>Raised after defaults are applied (seed or reset) so the Devices page can refresh.</summary>
+    event EventHandler? DefaultsApplied;
+}

--- a/src/Earmark.App/ViewModels/HomeViewModel.cs
+++ b/src/Earmark.App/ViewModels/HomeViewModel.cs
@@ -46,6 +46,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
     private readonly IWaveLinkService _waveLink;
     private readonly IWaveLinkVisualService _waveLinkVisuals;
     private readonly IDispatcherQueueProvider _dispatcher;
+    private readonly IDeviceDefaultsService _deviceDefaults;
     private WaveLinkChannelStyle? _lastAppliedStyle;
     private bool? _lastFilterForwarders;
     private bool? _lastShowAppIndicators;
@@ -84,6 +85,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         IWaveLinkVisualService waveLinkVisuals,
         INotificationService notifications,
         IDispatcherQueueProvider dispatcher,
+        IDeviceDefaultsService deviceDefaults,
         ILogger<HomeViewModel> logger)
     {
         _rules = rules ?? throw new ArgumentNullException(nameof(rules));
@@ -102,6 +104,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         _waveLinkVisuals = waveLinkVisuals ?? throw new ArgumentNullException(nameof(waveLinkVisuals));
         _notifications = notifications ?? throw new ArgumentNullException(nameof(notifications));
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _deviceDefaults = deviceDefaults ?? throw new ArgumentNullException(nameof(deviceDefaults));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         // Show-hidden is session-only: defaults to off on every launch.
@@ -144,6 +147,10 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         // place rather than rebuilding the grid (a rebuild flashes the ItemsRepeater). Filtered
         // to the style field so unrelated saves (hidden/pinned devices) don't trigger work.
         _settings.SettingsChanged += OnSettingsChanged;
+        // First-run seeding / the Settings "Reset to default" both mutate the persisted groups,
+        // order, and visibility behind our back. OnSettingsChanged deliberately doesn't rebuild on
+        // arbitrary saves, so the service signals a structural change explicitly -> rebuild.
+        _deviceDefaults.DefaultsApplied += OnAnythingChanged;
         SyncMeterOptions();
         RefreshHiddenApps();
 
@@ -1848,6 +1855,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         _waveLink.SnapshotChanged -= OnAnythingChanged;
         _waveLink.StateChanged -= OnAnythingChanged;
         _settings.SettingsChanged -= OnSettingsChanged;
+        _deviceDefaults.DefaultsApplied -= OnAnythingChanged;
         if (_peakTimer is not null)
         {
             _peakTimer.Tick -= OnPeakTick;

--- a/src/Earmark.App/ViewModels/SettingsViewModel.cs
+++ b/src/Earmark.App/ViewModels/SettingsViewModel.cs
@@ -15,20 +15,27 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private readonly ISettingsService _settings;
     private readonly IWaveLinkService _waveLink;
     private readonly IDispatcherQueueProvider _dispatcher;
+    private readonly IDeviceDefaultsService _defaults;
     private bool _suppress;
 
     public SettingsViewModel(
         ISettingsService settings,
         IWaveLinkService waveLink,
-        IDispatcherQueueProvider dispatcher)
+        IDispatcherQueueProvider dispatcher,
+        IDeviceDefaultsService defaults)
     {
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         _waveLink = waveLink ?? throw new ArgumentNullException(nameof(waveLink));
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _defaults = defaults ?? throw new ArgumentNullException(nameof(defaults));
         _waveLink.StateChanged += OnWaveLinkStateChanged;
         SyncFromSettings();
         SyncFromWaveLink();
     }
+
+    /// <summary>Restores the Devices page to its default groups, order, and visibility. Rules and all
+    /// other settings are left untouched. The Devices page rebuilds via the service's event.</summary>
+    public Task ResetDeviceLayoutAsync() => _defaults.ResetDeviceLayoutAsync();
 
     [ObservableProperty]
     public partial bool LaunchOnStartup { get; set; }

--- a/src/Earmark.App/Views/SettingsPage.xaml
+++ b/src/Earmark.App/Views/SettingsPage.xaml
@@ -184,6 +184,14 @@
                     </ctrl:SettingsExpander.Items>
                 </ctrl:SettingsExpander>
 
+                <ctrl:SettingsCard Header="Reset Devices page"
+                                   Description="Restore the default device groups, order, and visibility. Your rules and other settings aren't changed.">
+                    <ctrl:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE777;" />
+                    </ctrl:SettingsCard.HeaderIcon>
+                    <Button Content="Reset to default" Click="OnResetDeviceLayout" />
+                </ctrl:SettingsCard>
+
                 <TextBlock Text="System tray" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,12,0,0" />
                 <ctrl:SettingsExpander Header="Show tray icon"
                                        Description="Display the Earmark icon in the Windows notification area. The behaviours below need it on."

--- a/src/Earmark.App/Views/SettingsPage.xaml
+++ b/src/Earmark.App/Views/SettingsPage.xaml
@@ -185,7 +185,7 @@
                 </ctrl:SettingsExpander>
 
                 <ctrl:SettingsCard Header="Reset Devices page"
-                                   Description="Restore the default device groups, order, and visibility. Your rules and other settings aren't changed.">
+                                   Description="Restore the default device groups, order, and visibility, and un-hide any hidden app chips. Asks for confirmation first. Your rules and other settings aren't changed.">
                     <ctrl:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE777;" />
                     </ctrl:SettingsCard.HeaderIcon>

--- a/src/Earmark.App/Views/SettingsPage.xaml.cs
+++ b/src/Earmark.App/Views/SettingsPage.xaml.cs
@@ -60,6 +60,25 @@ public sealed partial class SettingsPage : Page
 
     private void OnResetMeterColour(object sender, RoutedEventArgs e) => ViewModel.ResetPeakMeterColour();
 
+    private async void OnResetDeviceLayout(object sender, RoutedEventArgs e)
+    {
+        var dialog = new ContentDialog
+        {
+            XamlRoot = XamlRoot,
+            Title = "Reset Devices page?",
+            Content = "This restores the default device groups, order, and visibility on the Devices page. "
+                + "Your rules and other settings aren't changed.",
+            PrimaryButtonText = "Reset",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Close,
+        };
+
+        if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+        {
+            await ViewModel.ResetDeviceLayoutAsync();
+        }
+    }
+
     private async void OnCheckForUpdates(object sender, RoutedEventArgs e) => await About.CheckForUpdatesAsync();
 
     private void OnOpenLatestRelease(object sender, RoutedEventArgs e) => About.OpenLatestRelease();

--- a/src/Earmark.App/Views/SettingsPage.xaml.cs
+++ b/src/Earmark.App/Views/SettingsPage.xaml.cs
@@ -66,8 +66,8 @@ public sealed partial class SettingsPage : Page
         {
             XamlRoot = XamlRoot,
             Title = "Reset Devices page?",
-            Content = "This restores the default device groups, order, and visibility on the Devices page. "
-                + "Your rules and other settings aren't changed.",
+            Content = "This restores the default device groups, order, and visibility on the Devices page, "
+                + "and un-hides any hidden app chips. Your rules and other settings aren't changed.",
             PrimaryButtonText = "Reset",
             CloseButtonText = "Cancel",
             DefaultButton = ContentDialogButton.Close,


### PR DESCRIPTION
## Summary

Adds a Settings "Reset to default" action for the Devices page, plus one-time seeding of starter device groups and example rules on a fresh install.

## Changes

- New `IDeviceDefaultsService` / `DeviceDefaultsService` owning the Devices-page defaults (group/visibility layout + the example rules).
- **Reset to default**: Settings > Devices > "Reset to default" (with a confirm dialog) restores the Devices-page groups, order, and visibility. Rules and all other settings are left untouched.
- **New-install seeding** (blank-slate only): a "Default Devices" group (default + communications render/capture, plus the first Wave Link mix) and a "Wave Link Channels" group (output-only virtual channels), plus two disabled example rules ("Set default volumes", "Set output device for app").
- Seeding keys off an empty config (no rules and no Devices-page state) rather than a persisted flag, so an existing install is never reseeded and an upgrade can't wipe a configured layout. The normal auto-hide-no-rules logic still applies.

## Testing

- [x] Manual testing on a Windows 11 host
- [x] Latest log confirms seeding is skipped on a configured install (`Existing config present; skipping new-install seeding`) and a blank-slate install seeds the two groups; `Applied rule ...` lines unaffected
- [ ] Unit tests added/updated under `tests/Earmark.Core.Tests` (service lives in `Earmark.App`; not covered by the Core test project)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings (`dotnet build src/Earmark.App/Earmark.App.csproj -c Debug -p:Platform=x64`)
- [x] No emoji / gitmoji in commit messages or PR title
- [x] Architecture boundary respected (app-level orchestration in `Earmark.App`; no domain logic added to Core/Audio)
- [ ] CLAUDE.md / README / CONTRIBUTING updated (behaviour change; AGENTS.md note could follow)