### PR TITLE
feat: device customisation panel (glyph + accent colour)

### DIFF
--- a/docs/features/customization-panel.md
+++ b/docs/features/customization-panel.md
@@ -1,2 +1,88 @@
-Right click any device to popup a modal allowing the user to 'override' the Glyph (provide a predefined set of glyphs relating to audio devices), and color (use the same color pattern as peak meter solid color options - but with more defaults to pick from)
-Additionally instead of using WaveLink colors like-for-like, match it to the closest FLuent color preset.
+# Device customisation panel
+
+Let the user override a device card's **glyph** and **accent colour** from a right-click menu on the Devices page. Both are per-device overrides keyed by endpoint id, persisted in `settings.json`, and win over the auto-derived visuals (name-based glyph, Wave Link accent).
+
+## Goal
+
+On the Devices page (`HomePage`), the icon and accent tile of each card are auto-derived: the glyph from the device name via `DeviceGlyphMapper`, the accent colour from a Wave Link channel's artwork (or none). The user can't change either. This feature adds a "Customise..." entry to the existing card context menu that opens a small picker for:
+
+1. **Glyph** - choose from the curated audio-device glyph set (the same icons `DeviceGlyphMapper` already uses), or "Auto" to fall back to the derived glyph.
+2. **Colour** - choose an accent tile colour from a Fluent swatch palette (the peak-meter swatches plus more defaults), a custom colour via `ColorPicker`, or "Auto" to fall back to the Wave Link accent / default tile.
+
+A user override always wins over the auto-derived value. "Auto" clears the override.
+
+## Current state (what exists today)
+
+- **Card context menu**: `Border.ContextFlyout` > `MenuFlyout` in [HomePage.xaml:64-117](../../src/Earmark.App/Views/HomePage.xaml#L64-L117). Existing items: hide/show device, show/hide volume controls, and group actions. Commands live on the `DeviceCard` view-model; group actions are `Click` handlers in [HomePage.xaml.cs](../../src/Earmark.App/Views/HomePage.xaml.cs) with `Tag="{x:Bind}"`.
+- **Per-device VM**: [`DeviceCard`](../../src/Earmark.App/ViewModels/DeviceCard.cs). Exposes `Endpoint` (carries the stable `Endpoint.Id`), `Glyph` (string, [line 554](../../src/Earmark.App/ViewModels/DeviceCard.cs#L554)), `WaveLinkTileBrush` / `ShowAccentTile` / `ShowDefaultTile` ([lines 615-626](../../src/Earmark.App/ViewModels/DeviceCard.cs#L615-L626)).
+- **Glyph precedence** ([line 554](../../src/Earmark.App/ViewModels/DeviceCard.cs#L554)): `_waveLinkGlyphOverride` (mix icon) > `_themedGlyph` (name-derived, resolved at construction) > render/mute fallback. There is **no user override slot yet** - this feature inserts one above all of these.
+- **Accent tile**: `WaveLinkTileBrush` is `_waveLinkAccent` wrapped in a `SolidColorBrush`. `_waveLinkAccent` is set only by `SetWaveLinkVisual` ([line 593](../../src/Earmark.App/ViewModels/DeviceCard.cs#L593)). Three overlaid `FontIcon`s + tile borders are bound to `ShowAccentTile`/`ShowDefaultTile` so theme-dependent fills stay `{ThemeResource}`. An absolute user colour behaves like a Wave Link accent (theme-independent).
+- **Curated glyph set**: [`DeviceGlyphMapper`](../../src/Earmark.App/ViewModels/DeviceGlyphMapper.cs) holds 10 Segoe Fluent glyphs as `private const string` (Game ``, Chat ``, Music ``, Monitor ``, Globe ``, Streaming ``, Headphones ``, Earbuds ``, Speakers ``, Microphone ``). Plus the two render/capture fallbacks (`` speaker, `` mic). These need to be exposed as a public, named, ordered list for the picker.
+- **Colour swatches**: the peak-meter solid-colour picker in [SettingsPage.xaml:152-191](../../src/Earmark.App/Views/SettingsPage.xaml#L152-L191) (a `Button` > `Flyout` with an `ItemsControl` of swatch borders + a `ColorPicker` + reset). Swatch list is `FluentSwatches` in [SettingsPage.xaml.cs:14-25](../../src/Earmark.App/Views/SettingsPage.xaml.cs#L14-L25): 7 colours (teal `#00B7C3`, blue `#0078D4`, purple `#8764B8`, magenta `#E3008C`, red `#E81123`, orange `#F7630C`, gold `#FFB900`) plus the green default. Stored as `#AARRGGBB` hex via `PeakMeterOptions.ToHex` / `ColourFromHex`.
+- **Per-device persistence**: [`DeviceConfig`](../../src/Earmark.App/Settings/AppSettings.cs#L173) in `AppSettings.Devices` (`Dictionary<string, DeviceConfig>`, keyed by `endpoint.Id`, case-insensitive). Nullable flags, pruned on save via `IsDefault`. `HomeViewModel.BuildCards` reads `cfg` per endpoint and passes flags into the `DeviceCard` constructor.
+
+## Design decisions
+
+- **Reuse, don't duplicate.** The colour picker is the established peak-meter pattern (`Button` > `Flyout` > swatch `ItemsControl` + `ColorPicker`). Extract the swatch markup + `ColorPicker` into a reusable `Controls/ColourPickerFlyout` (or a shared `UserControl`) so the Settings peak-meter picker and the device picker share one implementation and one swatch list. Per [AGENTS.md "Components and custom controls"](../../AGENTS.md), a one-off inline copy is not acceptable when two places need the same affordance. If extraction is too large for one pass, at minimum share the swatch colour list (move `FluentSwatches` to a single public source both consumers reference) and note the markup-sharing follow-up.
+- **Picker surface**: a **`Flyout`** anchored to the menu, not a `ContentDialog`. Matches the peak-meter precedent, stays contextual to the card, and is non-modal. The right-click `MenuFlyout` can't host a rich sub-panel cleanly, so add a "Customise..." `MenuFlyoutItem` whose `Click` opens a separate `Flyout` anchored to the card (or open it as a sub-section). Confirm the anchoring approach during implementation - if a `MenuFlyoutSubItem` can host the swatch grid acceptably, prefer that; otherwise a `Click` handler that shows a `Flyout` on the card `Border`.
+- **Glyph picker UI**: a wrap of selectable glyph buttons (each a `FontIcon` of one curated glyph) plus an "Auto" choice. Single-select; selection writes the chosen glyph string (or null for Auto).
+- **Override precedence**: user override > snapped auto accent > default tile. Add a `_userGlyphOverride` checked **first** in the `Glyph` getter, and a `_userAccent` checked **first** in the accent-tile path. `ShowAccentTile`/`ShowDefaultTile` must treat a user accent the same as a Wave Link accent (absolute colour, theme-independent, suppressed while muted/rule-locked).
+- **Snap the auto accent to the nearest Fluent palette colour (the default path).** When the user has *not* set a colour, do not render the raw Wave Link / icon-derived accent at face value. Snap it to the nearest colour in the Fluent palette (nearest by RGB Euclidean distance) and tint the tile with that. This is the resting state, not just a picker suggestion: a Wave Link device shows a Fluent-aligned accent out of the box. The snap happens where the auto accent is resolved (in `SetWaveLinkVisual` or at the point the tile brush is built) - store/use the snapped colour, not the artwork colour. When the picker opens, the swatch matching the snapped colour reads as the current selection.
+- **Swatch palette = the full Windows personalisation accent palette**, the same (or visually equivalent) grid Windows shows under Settings > Personalisation > Colours > Accent colour (the ~48 Windows accent swatches), not the seven peak-meter colours. Define this palette once as the shared swatch source. The peak-meter picker can keep its smaller curated set or adopt the full palette - decide during the shared-control extraction, but the device picker uses the full palette.
+- **Colour wheel hidden by default.** The picker shows the swatch grid only. A "Custom" affordance (button/toggle) reveals the `ColorPicker` (ring/spectrum + hex) for an off-palette colour. Default state is swatches-only; the wheel appears on demand.
+
+## Persistence
+
+Extend [`DeviceConfig`](../../src/Earmark.App/Settings/AppSettings.cs#L173):
+
+```csharp
+/// <summary>User-chosen glyph override (a single Segoe Fluent codepoint string). Null = derive
+/// the glyph automatically from the device name / Wave Link channel.</summary>
+public string? Glyph { get; set; }
+
+/// <summary>User-chosen accent tile colour as "#AARRGGBB". Null = use the Wave Link accent (or
+/// the default tile when there is none).</summary>
+public string? AccentColour { get; set; }
+```
+
+Update `IsDefault` to also require `Glyph is null && AccentColour is null`, so an all-default entry still prunes. Reuse `PeakMeterOptions.ToHex` / `ColourFromHex` for the colour string round-trip (or move those helpers somewhere shared if `PeakMeterOptions` isn't a sensible home for a device colour).
+
+`HomeViewModel.BuildCards` already does `deviceConfigs.TryGetValue(endpoint.Id, out var cfg)`; pass `cfg?.Glyph` and the parsed `cfg?.AccentColour` into the `DeviceCard` constructor (or a setter) alongside the existing flags.
+
+## Work
+
+1. **Expose the curated glyph set.** Promote the `DeviceGlyphMapper` glyph constants into a public, ordered, named list (e.g. `IReadOnlyList<(string Label, string Glyph)>`) the picker can bind to, including the speaker + mic fallbacks. Keep `DeviceGlyphMapper.TryResolve` working off the same source so the two don't drift.
+2. **Extend `DeviceConfig`** with `Glyph` + `AccentColour` and update `IsDefault` (above).
+3. **Add user-override slots to `DeviceCard`.** A `_userGlyphOverride` checked first in `Glyph`, and a `_userAccent` checked first in the accent-tile resolution. Add a method mirroring `SetWaveLinkVisual` (e.g. `SetUserCustomisation(string? glyph, Color? accent)`) that sets the fields, raises `OnPropertyChanged` for every affected visual property (`Glyph`, `WaveLinkTileBrush`, `ShowAccentTile`, `ShowDefaultTile`, the glyph-contrast brushes), and persists via the settings service. Decide ownership: either the card raises a "customisation changed" event the `HomeViewModel` persists, or the card writes through an injected settings service - follow whatever pattern the existing `ToggleUserVisibilityCommand` / hide-flag persistence uses (mirror it, don't invent a new path).
+4. **Wire `BuildCards`** to seed the new override fields from `cfg`.
+5. **Build the shared colour picker.** A reusable control in `src/Earmark.App/Controls/` driven by a `Color` dependency property. Default view = the **full Windows accent swatch grid** only. A "Custom" button/toggle reveals a `ColorPicker` (ring + hex) for off-palette colours; hidden until invoked. Define the full Fluent accent palette once as the shared swatch source. Point the new device picker at it; fold the Settings peak-meter picker onto the same control where it fits (it may keep its smaller curated swatch set, but must not duplicate picker markup).
+   - **Snapping helper.** Add a `NearestSwatch(Color)` (RGB Euclidean distance) over the palette. Used both for the default auto-accent snap (step 8) and to mark the active swatch when the picker opens.
+6. **Build the glyph picker.** A selectable wrap of the curated glyphs + an "Auto" option, single-select, bound to the card's current override (null => Auto selected).
+7. **Add the menu entry + picker surface.** A "Customise..." `MenuFlyoutItem` (icon e.g. `` Personalize / ``) in the card `ContextFlyout` above the group section, opening the glyph + colour picker `Flyout`. On apply, call the card's `SetUserCustomisation`; "Auto" on either axis clears that axis's override.
+8. **Snap the auto accent to the palette (default rendering).** Where the auto accent is resolved (in/around `SetWaveLinkVisual`), run the raw Wave Link / icon-derived colour through `NearestSwatch` and tint the tile with the snapped colour, not the artwork colour. This is the resting state for any device with no user colour set. When the picker opens, the swatch equal to the snapped colour reads as selected.
+9. **Reset.** "Auto" entries on both axes must round-trip to a pruned `DeviceConfig`. A device with neither override set produces no `Devices` entry (or an entry only carrying other flags).
+
+## Acceptance criteria
+
+**Done when:**
+- Right-clicking a device card shows a "Customise..." entry that opens a glyph + colour picker.
+- Picking a glyph from the curated set changes the card icon immediately and survives relaunch.
+- Picking a colour (swatch or custom) tints the card's accent tile immediately (theme-independent, suppressed while muted / rule-locked, matching Wave Link accent behaviour) and survives relaunch.
+- A user override visibly wins over the Wave Link accent / themed glyph for that device.
+- "Auto" on either axis clears that override and the card reverts to its derived visual.
+- A device with both axes on "Auto" leaves no `glyph`/`accentColour` in its persisted `DeviceConfig` (entry pruned if no other flags).
+- The colour picker shows the full Windows accent swatch palette; the wheel/`ColorPicker` is hidden until "Custom" is chosen.
+- A Wave Link device with no user colour shows an accent **snapped to the nearest Fluent palette colour**, not the raw artwork colour; the matching swatch reads as selected when the picker opens.
+- The device picker and the Settings peak-meter picker do not duplicate picker markup.
+
+**Out of scope:**
+- Renaming devices (the existing menu has group rename only; per-device rename is a separate feature).
+- Custom uploaded glyph images / arbitrary icon fonts - only the curated Segoe Fluent set.
+
+## Notes / gotchas (from AGENTS.md)
+
+- Rebuild + relaunch after every change; verify against the running app, not a green build.
+- `Padding`/`Margin` need a `Thickness`, never an `x:Double` `Spacing*` resource (throws at page load, not build time).
+- Two-way `x:Bind` on a value-type `SelectedItem` NREs during recycling - use `Mode=OneWay` + a `SelectionChanged`/`Click` handler.
+- Theme-dependent brushes must be `{ThemeResource}`; absolute accent colours (the user/Wave Link tile) are deliberately theme-independent.
+- New shared UI goes in `src/Earmark.App/Controls/` as a reusable control with dependency properties, not page-local markup.

--- a/src/Earmark.App/Controls/ColourSwatchPicker.xaml
+++ b/src/Earmark.App/Controls/ColourSwatchPicker.xaml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Earmark.App.Controls.ColourSwatchPicker"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ui="using:Windows.UI"
+    xmlns:controls="using:Earmark.App.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Spacing="{StaticResource SpacingMedium}" Width="280">
+        <TextBlock Text="Accent colour"
+                   Style="{StaticResource CaptionTextBlockStyle}"
+                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+        <!-- Auto / off-palette state row: shown above the grid so the current selection reads
+             even when it isn't one of the swatches. -->
+        <Button x:Name="AutoButton"
+                Content="Auto"
+                Visibility="Collapsed"
+                Click="OnAutoClicked"
+                HorizontalAlignment="Left" />
+
+        <!-- Swatch grid (the full Windows accent palette). -->
+        <ItemsControl x:Name="SwatchHost">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controls:WrapPanel HorizontalSpacing="6" VerticalSpacing="6" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate x:DataType="ui:Color">
+                    <Button Width="28" Height="28"
+                            Padding="0"
+                            Click="OnSwatchClicked"
+                            Tag="{x:Bind}"
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Stretch">
+                        <Border CornerRadius="{ThemeResource ControlCornerRadius}"
+                                Background="{x:Bind Converter={StaticResource ColorToBrushConverter}}" />
+                    </Button>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <!-- Custom colour: hidden behind a toggle so the default state is swatches-only. -->
+        <ToggleButton x:Name="CustomToggle"
+                      Content="Custom…"
+                      Checked="OnCustomToggled"
+                      Unchecked="OnCustomToggled"
+                      HorizontalAlignment="Left" />
+        <ColorPicker x:Name="WheelPicker"
+                     Visibility="Collapsed"
+                     ColorSpectrumShape="Ring"
+                     IsAlphaEnabled="False"
+                     IsMoreButtonVisible="True"
+                     IsColorSliderVisible="True"
+                     IsColorChannelTextInputVisible="False"
+                     IsHexInputVisible="True"
+                     ColorChanged="OnWheelColorChanged" />
+    </StackPanel>
+</UserControl>

--- a/src/Earmark.App/Controls/ColourSwatchPicker.xaml.cs
+++ b/src/Earmark.App/Controls/ColourSwatchPicker.xaml.cs
@@ -1,0 +1,94 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+using Windows.UI;
+
+namespace Earmark.App.Controls;
+
+/// <summary>
+/// Reusable accent-colour picker: the full Windows accent swatch grid (see
+/// <see cref="DeviceAccentPalette"/>) plus a "Custom…" toggle that reveals a <see cref="ColorPicker"/>
+/// ring/hex for off-palette colours. The wheel is hidden by default so the resting state is
+/// swatches-only. Shared by the device customisation flyout and the Settings peak-meter colour
+/// picker so the two don't duplicate picker markup.
+///
+/// <para><see cref="SelectedColour"/> is the chosen colour. When <see cref="AllowAuto"/> is set an
+/// "Auto" button is offered; choosing it sets <see cref="SelectedColour"/> to null (the consumer
+/// reads that as "fall back to the derived value").</para>
+/// </summary>
+public sealed partial class ColourSwatchPicker : UserControl
+{
+    private bool _suppressWheel;
+
+    public ColourSwatchPicker()
+    {
+        InitializeComponent();
+        SwatchHost.ItemsSource = DeviceAccentPalette.Swatches;
+        UpdateAutoState();
+    }
+
+    /// <summary>The selected colour. Null means "Auto" (only reachable when <see cref="AllowAuto"/>
+    /// is set). Two-way by convention.</summary>
+    public static readonly DependencyProperty SelectedColourProperty = DependencyProperty.Register(
+        nameof(SelectedColour), typeof(Color?), typeof(ColourSwatchPicker),
+        new PropertyMetadata(null, OnSelectedColourChanged));
+
+    public Color? SelectedColour
+    {
+        get => (Color?)GetValue(SelectedColourProperty);
+        set => SetValue(SelectedColourProperty, value);
+    }
+
+    /// <summary>When true, an "Auto" choice is offered that clears the selection to null.</summary>
+    public static readonly DependencyProperty AllowAutoProperty = DependencyProperty.Register(
+        nameof(AllowAuto), typeof(bool), typeof(ColourSwatchPicker),
+        new PropertyMetadata(false, (d, _) => ((ColourSwatchPicker)d).UpdateAutoState()));
+
+    public bool AllowAuto
+    {
+        get => (bool)GetValue(AllowAutoProperty);
+        set => SetValue(AllowAutoProperty, value);
+    }
+
+    private static void OnSelectedColourChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var picker = (ColourSwatchPicker)d;
+        picker.UpdateAutoState();
+        if (e.NewValue is Color c)
+        {
+            picker._suppressWheel = true;
+            picker.WheelPicker.Color = c;
+            picker._suppressWheel = false;
+        }
+    }
+
+    private void UpdateAutoState()
+    {
+        // The "Auto" button only makes sense when Auto is allowed AND something is currently set;
+        // tapping it clears back to Auto.
+        AutoButton.Visibility = AllowAuto && SelectedColour is not null
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    private void OnSwatchClicked(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { Tag: Color colour })
+        {
+            SelectedColour = colour;
+        }
+    }
+
+    private void OnAutoClicked(object sender, RoutedEventArgs e) => SelectedColour = null;
+
+    private void OnCustomToggled(object sender, RoutedEventArgs e)
+    {
+        WheelPicker.Visibility = CustomToggle.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void OnWheelColorChanged(ColorPicker sender, ColorChangedEventArgs args)
+    {
+        if (_suppressWheel) return;
+        SelectedColour = args.NewColor;
+    }
+}

--- a/src/Earmark.App/Controls/DeviceAccentPalette.cs
+++ b/src/Earmark.App/Controls/DeviceAccentPalette.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+
+using Windows.UI;
+
+namespace Earmark.App.Controls;
+
+/// <summary>
+/// The shared swatch source for device-accent and peak-meter colour pickers: the same grid Windows
+/// shows under Settings &gt; Personalisation &gt; Colours &gt; Accent colour (the 48 Windows accent
+/// swatches). Defined once here so every picker offers the same colours and the auto-accent snap
+/// (see <see cref="NearestSwatch"/>) lands on a colour the picker can mark as selected.
+/// </summary>
+public static class DeviceAccentPalette
+{
+    private static Color Rgb(byte r, byte g, byte b) => Color.FromArgb(0xFF, r, g, b);
+
+    /// <summary>
+    /// A bright, saturated accent palette drawn from the vivid end of the Windows accent set:
+    /// reds, oranges, golds, greens, teals, blues, purples, magentas and pinks at high
+    /// saturation. The dull grey / olive / neutral Windows swatches are deliberately excluded -
+    /// a device accent tile is meant to pop. Row-major.
+    /// </summary>
+    public static IReadOnlyList<Color> Swatches { get; } = new[]
+    {
+        // Reds / oranges / golds
+        Rgb(0xE8, 0x11, 0x23), Rgb(0xFF, 0x40, 0x43), Rgb(0xDA, 0x3B, 0x01), Rgb(0xF7, 0x63, 0x0C),
+        Rgb(0xFF, 0x8C, 0x00), Rgb(0xFF, 0xB9, 0x00), Rgb(0xFD, 0xD7, 0x00), Rgb(0xEF, 0x69, 0x50),
+        // Greens / limes
+        Rgb(0x6C, 0xBE, 0x00), Rgb(0x4C, 0xC1, 0x3A), Rgb(0x10, 0xB9, 0x3E), Rgb(0x00, 0xCC, 0x6A),
+        Rgb(0x00, 0xB2, 0x94), Rgb(0x00, 0xCB, 0xB6), Rgb(0x03, 0xB5, 0x8C), Rgb(0x10, 0x9E, 0x10),
+        // Teals / cyans / blues
+        Rgb(0x00, 0xB7, 0xC3), Rgb(0x00, 0xBC, 0xF2), Rgb(0x00, 0x99, 0xBC), Rgb(0x00, 0x91, 0xF8),
+        Rgb(0x00, 0x78, 0xD4), Rgb(0x00, 0x63, 0xB1), Rgb(0x40, 0x71, 0xF7), Rgb(0x56, 0x73, 0xC3),
+        // Purples / violets
+        Rgb(0x6B, 0x69, 0xD6), Rgb(0x74, 0x42, 0xCC), Rgb(0x88, 0x4B, 0xD8), Rgb(0x89, 0x17, 0xC4),
+        Rgb(0xB1, 0x46, 0xC2), Rgb(0xC2, 0x39, 0xB3), Rgb(0x9A, 0x00, 0x89), Rgb(0x77, 0x00, 0xA8),
+        // Magentas / pinks
+        Rgb(0xE3, 0x00, 0x8C), Rgb(0xFF, 0x00, 0x99), Rgb(0xEA, 0x00, 0x5E), Rgb(0xFF, 0x43, 0x88),
+        Rgb(0xC3, 0x0C, 0x52), Rgb(0xE7, 0x48, 0x56), Rgb(0xFF, 0x6B, 0x9D), Rgb(0xD1, 0x34, 0x38),
+    };
+
+    /// <summary>
+    /// Returns the palette swatch closest to <paramref name="colour"/> by RGB Euclidean distance.
+    /// Used both to snap an auto-derived accent onto the palette (the resting tile colour) and to
+    /// mark the active swatch when the picker opens.
+    /// </summary>
+    public static Color NearestSwatch(Color colour)
+    {
+        var best = Swatches[0];
+        var bestDist = int.MaxValue;
+        foreach (var s in Swatches)
+        {
+            var dr = s.R - colour.R;
+            var dg = s.G - colour.G;
+            var db = s.B - colour.B;
+            var dist = (dr * dr) + (dg * dg) + (db * db);
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                best = s;
+            }
+        }
+        return best;
+    }
+
+    /// <summary>Serialises a colour to "#AARRGGBB" (matches <c>PeakMeterOptions.ToHex</c>).</summary>
+    public static string ToHex(Color c) => $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}";
+
+    /// <summary>Parses an "#AARRGGBB" string to a <see cref="Color"/>, or null when the input is
+    /// null / malformed. Unlike <c>PeakMeterOptions.ColourFromHex</c> this has no colour fallback,
+    /// so a missing device override stays null (no accent) rather than snapping to a default.</summary>
+    public static Color? TryParseHex(string? hex)
+    {
+        if (string.IsNullOrWhiteSpace(hex)) return null;
+        var s = hex.TrimStart('#');
+        if (s.Length == 8 && uint.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var argb))
+        {
+            return Color.FromArgb((byte)(argb >> 24), (byte)(argb >> 16), (byte)(argb >> 8), (byte)argb);
+        }
+        return null;
+    }
+}

--- a/src/Earmark.App/Settings/AppSettings.cs
+++ b/src/Earmark.App/Settings/AppSettings.cs
@@ -139,6 +139,15 @@ public sealed class AppSettings
     /// </summary>
     public List<HiddenApp> HiddenApps { get; set; } = new();
 
+    /// <summary>
+    /// Apps hidden from a single device card's chip row, via a chip's "Hide this app &gt; On this
+    /// device" context menu. Unlike <see cref="HiddenApps"/> (hidden everywhere), these are keyed by
+    /// the app's <see cref="Earmark.Core.Models.AudioSession.IdentityKey"/> paired with the card's
+    /// <see cref="Earmark.Core.Models.AudioEndpoint.Id"/>, so the app still shows on every other card.
+    /// Managed (unhidden) from Settings &gt; App indicators alongside the global hides.
+    /// </summary>
+    public List<HiddenAppOnDevice> HiddenAppsOnDevice { get; set; } = new();
+
     /// <summary>Persisted window size in physical pixels. Null until the user has resized
     /// at least once (so first launch picks the WinUI default).</summary>
     public int? WindowWidth { get; set; }
@@ -167,6 +176,29 @@ public sealed class HiddenApp
 }
 
 /// <summary>
+/// One app hidden from a single device card's chip row. Keyed by the app's
+/// <see cref="Earmark.Core.Models.AudioSession.IdentityKey"/> (<see cref="Key"/>) plus the card's
+/// <see cref="Earmark.Core.Models.AudioEndpoint.Id"/> (<see cref="EndpointId"/>). <see cref="Name"/>
+/// and <see cref="DeviceName"/> are the friendly labels captured at hide time so the manage list
+/// reads "Discord - on Speakers" without the app running or the device present.
+/// </summary>
+public sealed class HiddenAppOnDevice
+{
+    /// <summary>Match key: the app's <see cref="Earmark.Core.Models.AudioSession.IdentityKey"/>.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>The card's <see cref="Earmark.Core.Models.AudioEndpoint.Id"/> the app is hidden on.</summary>
+    public string EndpointId { get; set; } = string.Empty;
+
+    /// <summary>Friendly app name captured at hide time. Null falls back to a name derived from
+    /// <see cref="Key"/>.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Friendly endpoint name captured at hide time, shown as context in the manage list.</summary>
+    public string? DeviceName { get; set; }
+}
+
+/// <summary>
 /// Per-device user configuration. Flags are nullable so an unset flag is omitted from the JSON
 /// (null = the default), keeping persisted entries compact; null is read as false.
 /// </summary>
@@ -184,10 +216,19 @@ public sealed class DeviceConfig
     /// knob), Windows still reports a writable control, so this is a manual opt-out.</summary>
     public bool? VolumeControlsHidden { get; set; }
 
+    /// <summary>User-chosen glyph override (a single Segoe Fluent codepoint string). Null = derive
+    /// the glyph automatically from the device name / Wave Link channel.</summary>
+    public string? Glyph { get; set; }
+
+    /// <summary>User-chosen accent tile colour as "#AARRGGBB". Null = use the Wave Link accent (or
+    /// the default tile when there is none).</summary>
+    public string? AccentColour { get; set; }
+
     /// <summary>True when every flag is unset/false, so the entry carries no information and can be
     /// pruned from the map on save. Not serialised (it's a derived helper, not stored state).</summary>
     [JsonIgnore]
-    public bool IsDefault => Hidden is not true && Pinned is not true && VolumeControlsHidden is not true;
+    public bool IsDefault => Hidden is not true && Pinned is not true && VolumeControlsHidden is not true
+        && Glyph is null && AccentColour is null;
 }
 
 /// <summary>

--- a/src/Earmark.App/ViewModels/AppChip.cs
+++ b/src/Earmark.App/ViewModels/AppChip.cs
@@ -79,10 +79,11 @@ public partial class AppChip : ObservableObject, IWrapOrdered
     }
 
     private readonly Action<AppChip>? _onHide;
+    private readonly Action<AppChip>? _onHideOnDevice;
     private readonly Action<AppChip>? _onClose;
     private readonly Action<AppChip>? _onTerminate;
 
-    public AppChip(AudioSession session, string placementEndpointId, ISessionIconService iconService, PeakMeterOptions meterOptions, RoutingRule? lockingRule, bool startsActive = true, DeviceCard? ownerCard = null, Action<AppChip>? onHide = null, Action<AppChip>? onClose = null, Action<AppChip>? onTerminate = null, bool canControlProcess = false, bool canCloseProcess = false, bool isElevated = false)
+    public AppChip(AudioSession session, string placementEndpointId, ISessionIconService iconService, PeakMeterOptions meterOptions, RoutingRule? lockingRule, bool startsActive = true, DeviceCard? ownerCard = null, Action<AppChip>? onHide = null, Action<AppChip>? onHideOnDevice = null, Action<AppChip>? onClose = null, Action<AppChip>? onTerminate = null, bool canControlProcess = false, bool canCloseProcess = false, bool isElevated = false)
     {
         Session = session ?? throw new ArgumentNullException(nameof(session));
         PlacementEndpointId = placementEndpointId ?? throw new ArgumentNullException(nameof(placementEndpointId));
@@ -91,6 +92,7 @@ public partial class AppChip : ObservableObject, IWrapOrdered
         LockingRule = lockingRule;
         OwnerCard = ownerCard;
         _onHide = onHide;
+        _onHideOnDevice = onHideOnDevice;
         _onClose = onClose;
         _onTerminate = onTerminate;
         CanControlProcess = canControlProcess;
@@ -195,6 +197,11 @@ public partial class AppChip : ObservableObject, IWrapOrdered
     /// only the chip is suppressed). Persisted via <c>HomeViewModel</c>; reversible from Settings.</summary>
     [RelayCommand]
     private void Hide() => _onHide?.Invoke(this);
+
+    /// <summary>Hides this app's chip on the owning card's device only (it still shows on other cards,
+    /// and still routes / plays). Persisted via <c>HomeViewModel</c>; reversible from Settings.</summary>
+    [RelayCommand]
+    private void HideOnDevice() => _onHideOnDevice?.Invoke(this);
 
     /// <summary>Politely closes the app (WM_CLOSE, the SIGTERM equivalent) so it can save / prompt.
     /// Routed through <c>HomeViewModel</c>, which reports any failure as a toast.</summary>

--- a/src/Earmark.App/ViewModels/DeviceCard.cs
+++ b/src/Earmark.App/ViewModels/DeviceCard.cs
@@ -35,6 +35,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     private readonly IEndpointWriter _writer;
     private readonly Action<DeviceCard, VisibilityState> _onVisibilityToggled;
     private readonly Action<DeviceCard> _onVolumeControlsToggled;
+    private readonly Action<DeviceCard> _onCustomisationChanged;
     private bool _suppressVolumeWrite;
     private bool _showHidden;
     private float _leftHold;
@@ -66,13 +67,19 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         bool showHidden,
         PeakMeterOptions meterOptions,
         bool isVolumeControlsHiddenByUser,
+        string? userGlyphOverride,
+        Color? userAccent,
         Action<DeviceCard, VisibilityState> onUserVisibilityToggled,
-        Action<DeviceCard> onVolumeControlsToggled)
+        Action<DeviceCard> onVolumeControlsToggled,
+        Action<DeviceCard> onCustomisationChanged)
     {
         _endpoints = endpoints;
         _writer = writer;
         _onVisibilityToggled = onUserVisibilityToggled;
         _onVolumeControlsToggled = onVolumeControlsToggled;
+        _onCustomisationChanged = onCustomisationChanged;
+        _userGlyphOverride = userGlyphOverride;
+        _userAccent = userAccent;
         MeterOptions = meterOptions;
         Endpoint = endpoint;
         _split = SplitFriendlyName(endpoint.FriendlyName);
@@ -555,6 +562,9 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     {
         get
         {
+            // A user-chosen glyph wins over everything below.
+            if (_userGlyphOverride is not null) return _userGlyphOverride;
+
             // A Wave Link mix exposes a named icon (no bitmap); we map that to the closest
             // Fluent glyph and let it win over the device-name guess below.
             if (_waveLinkGlyphOverride is not null) return _waveLinkGlyphOverride;
@@ -588,8 +598,15 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     private ImageSource? _waveLinkIcon;
     private string? _waveLinkGlyphOverride;
 
+    // User overrides win over the Wave Link / themed visuals. A null override defers to the
+    // auto-derived value ("Auto"). Seeded from the persisted DeviceConfig at construction.
+    private string? _userGlyphOverride;
+    private Color? _userAccent;
+
     /// <summary>Applies (or clears) the Wave Link visual. Called on the UI thread by the Home
-    /// view-model after a rebuild or a style-setting change.</summary>
+    /// view-model after a rebuild or a style-setting change. The caller snaps an artwork-derived
+    /// accent to the nearest Fluent palette colour before passing it (the white mix tile is passed
+    /// as-is); a user override, applied separately, still wins over this.</summary>
     public void SetWaveLinkVisual(Color? accent, ImageSource? icon, string? glyphOverride)
     {
         _waveLinkAccent = accent;
@@ -608,22 +625,59 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         OnPropertyChanged(nameof(Glyph));
     }
 
-    public ImageSource? WaveLinkIconSource => _waveLinkIcon;
-    public bool ShowWaveLinkIcon => _waveLinkIcon is not null;
-    public bool ShowGlyph => _waveLinkIcon is null;
+    /// <summary>
+    /// Applies (or clears) the user's customisation overrides and persists them via the host.
+    /// A null <paramref name="glyph"/> or <paramref name="accent"/> means "Auto" for that axis -
+    /// the card falls back to its derived glyph / Wave Link accent. Mirrors
+    /// <see cref="SetWaveLinkVisual"/> in the set of visual properties it refreshes.
+    /// </summary>
+    public void SetUserCustomisation(string? glyph, Color? accent)
+    {
+        _userGlyphOverride = glyph;
+        _userAccent = accent;
+        OnPropertyChanged(nameof(Glyph));
+        OnPropertyChanged(nameof(ShowAccentTile));
+        OnPropertyChanged(nameof(ShowDefaultTile));
+        OnPropertyChanged(nameof(WaveLinkTileBrush));
+        OnPropertyChanged(nameof(GlyphContrastBrush));
+        OnPropertyChanged(nameof(GlyphOnAccent));
+        OnPropertyChanged(nameof(GlyphMutedThemed));
+        OnPropertyChanged(nameof(GlyphNormalThemed));
+        OnPropertyChanged(nameof(CurrentGlyphOverride));
+        OnPropertyChanged(nameof(CurrentAccent));
+        _onCustomisationChanged?.Invoke(this);
+    }
 
-    /// <summary>Absolute (theme-independent) accent fill for the icon tile: the Wave Link
-    /// channel colour, or white for a mix (mixes carry only a monochrome named icon). Null when
-    /// no tint applies.</summary>
-    public Brush? WaveLinkTileBrush => _waveLinkAccent is Color c ? new SolidColorBrush(c) : null;
+    /// <summary>Current user glyph override (null = Auto), read by the picker to seed selection.</summary>
+    public string? CurrentGlyphOverride => _userGlyphOverride;
+
+    /// <summary>Current user accent override (null = Auto), read by the picker to seed selection.</summary>
+    public Color? CurrentAccent => _userAccent;
+
+    /// <summary>The accent actually painted on the tile: a user override wins over the snapped
+    /// Wave Link accent.</summary>
+    private Color? EffectiveAccent => _userAccent ?? _waveLinkAccent;
+
+    public ImageSource? WaveLinkIconSource => _waveLinkIcon;
+
+    // A user accent override hides the Wave Link bitmap so the chosen tile colour + glyph show.
+    public bool ShowWaveLinkIcon => _waveLinkIcon is not null && _userAccent is null;
+    public bool ShowGlyph => !ShowWaveLinkIcon;
+
+    /// <summary>Absolute (theme-independent) accent fill for the icon tile: the user override, the
+    /// Wave Link channel colour, or white for a mix. Null when no tint applies.</summary>
+    public Brush? WaveLinkTileBrush => EffectiveAccent is Color c ? new SolidColorBrush(c) : null;
 
     /// <summary>Show the absolute-colour accent tile: a tint exists, the device isn't muted (the
-    /// muted card tint owns that signal), and it isn't showing a bitmap or rule-locked.</summary>
-    public bool ShowAccentTile => _waveLinkAccent.HasValue && !IsMuted && _waveLinkIcon is null && !IsMuteLockedByRule;
+    /// muted card tint owns that signal), and it isn't showing a bitmap. A rule-lock suppresses the
+    /// auto Wave Link accent (the lock owns the tile state), but a deliberate <em>user</em> colour
+    /// is honoured regardless - the user explicitly chose it.</summary>
+    public bool ShowAccentTile => EffectiveAccent.HasValue && !IsMuted && !ShowWaveLinkIcon
+        && (_userAccent is not null || !IsMuteLockedByRule);
 
-    /// <summary>Show the default theme tile ({ThemeResource} subtle fill): no Wave Link tint or
-    /// bitmap, and not rule-locked (locked stays transparent / non-interactive).</summary>
-    public bool ShowDefaultTile => _waveLinkIcon is null && !IsMuteLockedByRule && !ShowAccentTile;
+    /// <summary>Show the default theme tile ({ThemeResource} subtle fill): no tint or bitmap, and
+    /// not rule-locked (a rule-locked device with no user accent stays transparent / non-interactive).</summary>
+    public bool ShowDefaultTile => !ShowWaveLinkIcon && !IsMuteLockedByRule && !ShowAccentTile;
 
     // The glyph is drawn by one of three overlaid FontIcons in XAML, chosen by the bools below,
     // so the two theme-dependent colours can stay {ThemeResource} (which a code-resolved brush
@@ -635,7 +689,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
 
     /// <summary>Absolute contrast colour (near-black or white) for a glyph sitting on an accent
     /// or white tile. Null when there's no tile colour.</summary>
-    public Brush? GlyphContrastBrush => _waveLinkAccent is Color c ? new SolidColorBrush(ContrastingGlyph(c)) : null;
+    public Brush? GlyphContrastBrush => EffectiveAccent is Color c ? new SolidColorBrush(ContrastingGlyph(c)) : null;
 
     public bool GlyphOnAccent => ShowGlyph && ShowAccentTile;
     public bool GlyphMutedThemed => ShowGlyph && !ShowAccentTile && IsMuted;

--- a/src/Earmark.App/ViewModels/DeviceGlyphMapper.cs
+++ b/src/Earmark.App/ViewModels/DeviceGlyphMapper.cs
@@ -1,5 +1,13 @@
 namespace Earmark.App.ViewModels;
 
+/// <summary>One selectable glyph in the customisation picker. <see cref="Glyph"/> null = the
+/// "Auto" choice (fall back to the derived glyph).</summary>
+public sealed record GlyphChoice(string Label, string? Glyph)
+{
+    public bool IsAuto => Glyph is null;
+    public bool HasGlyph => Glyph is not null;
+}
+
 /// <summary>
 /// Maps an audio device's user-facing name to a thematic Segoe Fluent glyph so the device
 /// card icon reads at a glance instead of every endpoint sharing the speaker. Covers the
@@ -31,6 +39,55 @@ internal static class DeviceGlyphMapper
     private const string Earbuds = "";    // Earbud (in-ear)
     private const string Speakers = "";   // Speakers (the device-picker icon)
     private const string Microphone = ""; // Microphone
+
+
+    // Extra device-type glyphs offered only in the customisation picker (not used by
+    // auto-resolution). Codepoints from the Segoe Fluent Icons set; verify each renders before
+    // relying on it. Declared as \u escapes so the literal is unambiguous regardless of editor.
+    private const string Headset = "";    // Headset (headphones + boom mic)
+    private const string Equalizer = "";  // Equalizer (mixer / EQ)
+    private const string Bluetooth = "";  // Bluetooth
+    private const string Wifi = "";       // Wifi (wireless / network audio)
+    private const string Cast = "";       // Connect (cast to device)
+    private const string Project = "";    // MiracastLogoSmall (project / cast)
+    private const string Usb = "";        // USB
+    private const string Phone = "";      // Phone
+    private const string Laptop = "";     // DeviceLaptopNoPic
+
+    /// <summary>
+    /// The curated glyph set the customisation picker offers, in display order. Includes the
+    /// themed glyphs plus the speaker / mic fallbacks so a user can pin any of them explicitly.
+    /// Kept as the single source of glyph codepoints so the picker and <see cref="TryResolve"/>
+    /// can't drift.
+    /// </summary>
+    public static IReadOnlyList<(string Label, string Glyph)> CuratedGlyphs { get; } = new[]
+    {
+        ("Speakers", Speakers),
+        ("Headphones", Headphones),
+        ("Headset", Headset),
+        ("Earbuds", Earbuds),
+        ("Microphone", Microphone),
+        ("Game", Game),
+        ("Chat", Chat),
+        ("Music", Music),
+        ("Monitor", Monitor),
+        ("Browser", Globe),
+        ("Streaming", Streaming),
+        ("Equalizer", Equalizer),
+        ("Bluetooth", Bluetooth),
+        ("WiFi", Wifi),
+        ("Cast", Cast),
+        ("Project", Project),
+        ("USB", Usb),
+        ("Phone", Phone),
+        ("Laptop", Laptop),
+    };
+
+    /// <summary>Picker model: an "Auto" choice followed by every curated glyph.</summary>
+    public static IReadOnlyList<GlyphChoice> GlyphChoices { get; } =
+        new[] { new GlyphChoice("Auto", null) }
+            .Concat(CuratedGlyphs.Select(g => new GlyphChoice(g.Label, g.Glyph)))
+            .ToList();
 
     // Ordered: more-specific prefixes first so they win over broader ones.
     private static readonly (string Prefix, string Glyph)[] _patterns =

--- a/src/Earmark.App/ViewModels/HomeViewModel.cs
+++ b/src/Earmark.App/ViewModels/HomeViewModel.cs
@@ -56,9 +56,14 @@ public partial class HomeViewModel : ObservableObject, IDisposable
     private bool? _lastShowAppIndicators;
     private bool? _lastAlwaysShowPinned;
     private int? _lastHiddenAppsCount;
+    private int? _lastHiddenAppsOnDeviceCount;
     /// <summary>Identity keys of apps the user has permanently hidden from the chip rows, mirrored
     /// from <see cref="AppSettings.HiddenApps"/> for O(1) lookups on the 20Hz tick.</summary>
     private readonly HashSet<string> _hiddenAppKeys = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>Composite "identityKey\0endpointId" keys of apps hidden on a single device, mirrored
+    /// from <see cref="AppSettings.HiddenAppsOnDevice"/> for O(1) lookups on the 20Hz tick. Built via
+    /// <see cref="DeviceHideKey"/>.</summary>
+    private readonly HashSet<string> _hiddenAppOnDeviceKeys = new(StringComparer.OrdinalIgnoreCase);
     private readonly INotificationService _notifications;
     private readonly IInAppNotificationService _inAppNotifications;
     private readonly IProcessControlService _processControl;
@@ -380,6 +385,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
                 {
                     if (!ShouldShow(session)) continue;
                     if (IsAppHidden(session.IdentityKey)) continue;
+                    if (IsAppHiddenOnDevice(session.IdentityKey, card.Endpoint.Id)) continue;
                     if (seenAppsOnThisCard.Contains(session.IdentityKey)) continue;
 
                     var livePeak = _sessionMeters.GetPeak(session.ProcessId, card.Endpoint.Id) ?? 0f;
@@ -389,7 +395,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
                         .Concat(_endpoints.GetEndpoints(EndpointFlow.Capture))
                         .ToList();
                     var match = _matcher.FindAppRoute(session, EndpointFlow.Render, rulesSnapshot, combinedEndpointsCache, sessionsSnapshot);
-                    var revivedChip = new AppChip(session, card.Endpoint.Id, _iconService, _meterOptions, match?.Rule, ownerCard: card, onHide: HideApp, onClose: CloseApp, onTerminate: TerminateApp, canControlProcess: _processControl.CanControl(session.ProcessId), canCloseProcess: _processControl.CanClose(session.ProcessId), isElevated: _processControl.IsElevated(session.ProcessId))
+                    var revivedChip = new AppChip(session, card.Endpoint.Id, _iconService, _meterOptions, match?.Rule, ownerCard: card, onHide: HideApp, onHideOnDevice: HideAppOnDevice, onClose: CloseApp, onTerminate: TerminateApp, canControlProcess: _processControl.CanControl(session.ProcessId), canCloseProcess: _processControl.CanClose(session.ProcessId), isElevated: _processControl.IsElevated(session.ProcessId))
                     {
                         RulePinnedHere = match is not null &&
                             string.Equals(match.Endpoint.Id, card.Endpoint.Id, StringComparison.OrdinalIgnoreCase),
@@ -640,7 +646,8 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             // A hidden-apps add/remove (count change) is detected here too - unhiding from the
             // Settings modal lands via this path. RefreshHiddenApps updates the count baseline so
             // it doesn't re-trigger; the chip's own Hide path already updated it before saving.
-            var hiddenAppsChanged = _settings.Current.HiddenApps.Count != _lastHiddenAppsCount;
+            var hiddenAppsChanged = _settings.Current.HiddenApps.Count != _lastHiddenAppsCount ||
+                _settings.Current.HiddenAppsOnDevice.Count != _lastHiddenAppsOnDeviceCount;
             if (hiddenAppsChanged) RefreshHiddenApps();
             // The always-show-pinned toggle changes which chips exist (silent pinned apps gain or
             // lose their forced chip), so a change re-runs the in-place reconcile alongside the
@@ -714,7 +721,10 @@ public partial class HomeViewModel : ObservableObject, IDisposable
                 else
                 {
                     var accent = await _waveLinkVisuals.GetAccentColourAsync(channel.ImageData).ConfigureAwait(true);
-                    card.SetWaveLinkVisual(accent, null, null);
+                    // Snap the raw artwork colour onto the Fluent palette so the resting tile reads
+                    // as palette-aligned (and the picker can mark the matching swatch).
+                    var snapped = accent is { } a ? Controls.DeviceAccentPalette.NearestSwatch(a) : (Color?)null;
+                    card.SetWaveLinkVisual(snapped, null, null);
                 }
             }
             else if (mixMap.TryGetValue(card.Endpoint.Id, out var mix))
@@ -923,8 +933,11 @@ public partial class HomeViewModel : ObservableObject, IDisposable
                 showHidden,
                 _meterOptions,
                 cfg?.VolumeControlsHidden == true,
+                cfg?.Glyph,
+                Controls.DeviceAccentPalette.TryParseHex(cfg?.AccentColour),
                 OnCardVisibilityToggled,
-                OnCardVolumeControlsToggled);
+                OnCardVolumeControlsToggled,
+                OnCardCustomisationChanged);
             // Group membership + apps are filled later on the UI thread (SyncBlocks / SyncAllCardsApps);
             // ObservableCollection mutations have to happen there.
             cards.Add(card);
@@ -1012,14 +1025,16 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             return;
         }
 
-        // Drop any chip whose app the user has permanently hidden (the set may have grown since the
-        // chip was placed). The additions loop below skips hidden apps too, so nothing re-adds them.
-        if (_hiddenAppKeys.Count > 0)
+        // Drop any chip whose app the user has hidden - globally, or on this card's device (either set
+        // may have grown since the chip was placed). The additions loop below skips both too, so
+        // nothing re-adds them.
+        if (_hiddenAppKeys.Count > 0 || _hiddenAppOnDeviceKeys.Count > 0)
         {
             var removedHidden = false;
             for (var i = card.Apps.Count - 1; i >= 0; i--)
             {
-                if (IsAppHidden(card.Apps[i].Session.IdentityKey))
+                var ik = card.Apps[i].Session.IdentityKey;
+                if (IsAppHidden(ik) || IsAppHiddenOnDevice(ik, card.Endpoint.Id))
                 {
                     card.Apps.RemoveAt(i);
                     removedHidden = true;
@@ -1108,7 +1123,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             if (!ShouldShow(session)) continue;
 
             var key = session.IdentityKey;
-            if (IsAppHidden(key)) continue;
+            if (IsAppHidden(key) || IsAppHiddenOnDevice(key, card.Endpoint.Id)) continue;
             routeByPid.TryGetValue(session.ProcessId, out var match);
             var pinnedHere = match is not null &&
                 string.Equals(match.Endpoint.Id, card.Endpoint.Id, StringComparison.OrdinalIgnoreCase);
@@ -1142,7 +1157,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         foreach (var add in additions.Values
             .OrderBy(a => a.Session.IsSystemSounds ? "System Sounds" : a.Session.DisplayName, StringComparer.OrdinalIgnoreCase))
         {
-            var chip = new AppChip(add.Session, card.Endpoint.Id, _iconService, _meterOptions, add.Rule, startsActive: add.Audible, ownerCard: card, onHide: HideApp, onClose: CloseApp, onTerminate: TerminateApp, canControlProcess: _processControl.CanControl(add.Session.ProcessId), canCloseProcess: _processControl.CanClose(add.Session.ProcessId), isElevated: _processControl.IsElevated(add.Session.ProcessId))
+            var chip = new AppChip(add.Session, card.Endpoint.Id, _iconService, _meterOptions, add.Rule, startsActive: add.Audible, ownerCard: card, onHide: HideApp, onHideOnDevice: HideAppOnDevice, onClose: CloseApp, onTerminate: TerminateApp, canControlProcess: _processControl.CanControl(add.Session.ProcessId), canCloseProcess: _processControl.CanClose(add.Session.ProcessId), isElevated: _processControl.IsElevated(add.Session.ProcessId))
             {
                 RulePinnedHere = add.PinnedHere,
             };
@@ -1303,8 +1318,9 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         }
     }
 
-    /// <summary>Rebuilds <see cref="_hiddenAppKeys"/> from <see cref="AppSettings.HiddenApps"/> and
-    /// refreshes the count baseline used to detect changes in <see cref="OnSettingsChanged"/>.</summary>
+    /// <summary>Rebuilds <see cref="_hiddenAppKeys"/> and <see cref="_hiddenAppOnDeviceKeys"/> from
+    /// settings and refreshes the count baselines used to detect changes in
+    /// <see cref="OnSettingsChanged"/>.</summary>
     private void RefreshHiddenApps()
     {
         _hiddenAppKeys.Clear();
@@ -1313,9 +1329,25 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             if (!string.IsNullOrEmpty(app.Key)) _hiddenAppKeys.Add(app.Key);
         }
         _lastHiddenAppsCount = _settings.Current.HiddenApps.Count;
+
+        _hiddenAppOnDeviceKeys.Clear();
+        foreach (var app in _settings.Current.HiddenAppsOnDevice)
+        {
+            if (!string.IsNullOrEmpty(app.Key) && !string.IsNullOrEmpty(app.EndpointId))
+                _hiddenAppOnDeviceKeys.Add(DeviceHideKey(app.Key, app.EndpointId));
+        }
+        _lastHiddenAppsOnDeviceCount = _settings.Current.HiddenAppsOnDevice.Count;
     }
 
+    /// <summary>Composite lookup key for a per-device hide: the app's identity key and the card's
+    /// endpoint id joined by NUL (both compared case-insensitively).</summary>
+    private static string DeviceHideKey(string identityKey, string endpointId) =>
+        identityKey + "\0" + endpointId;
+
     private bool IsAppHidden(string identityKey) => _hiddenAppKeys.Contains(identityKey);
+
+    private bool IsAppHiddenOnDevice(string identityKey, string endpointId) =>
+        _hiddenAppOnDeviceKeys.Count > 0 && _hiddenAppOnDeviceKeys.Contains(DeviceHideKey(identityKey, endpointId));
 
     /// <summary>
     /// Permanently hides an app from every device card's chip row (the chip's "Hide this app"
@@ -1355,6 +1387,57 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         }
 
         _logger.LogInformation("App hidden from chip rows: key='{Key}'", key);
+        QueueSettingsSave();
+    }
+
+    /// <summary>
+    /// Hides an app's chip on the owning card's device only (the chip's "Hide this app &gt; On this
+    /// device" context menu). The app still shows on every other card. Records the app's identity key
+    /// + the card's endpoint id (plus friendly names for the manage list), drops the matching chip on
+    /// that card now, and persists. Reversible from Settings &gt; App indicators.
+    /// </summary>
+    public void HideAppOnDevice(AppChip chip)
+    {
+        ArgumentNullException.ThrowIfNull(chip);
+        var key = chip.Session.IdentityKey;
+        var endpointId = chip.OwnerCard?.Endpoint.Id ?? chip.PlacementEndpointId;
+        if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(endpointId)) return;
+
+        PushLayoutUndo();   // Ctrl+Z un-hides the app
+        if (!_settings.Current.HiddenAppsOnDevice.Any(h =>
+                string.Equals(h.Key, key, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(h.EndpointId, endpointId, StringComparison.OrdinalIgnoreCase)))
+        {
+            _settings.Current.HiddenAppsOnDevice.Add(new HiddenAppOnDevice
+            {
+                Key = key,
+                EndpointId = endpointId,
+                Name = chip.DisplayLabel,
+                DeviceName = chip.OwnerCard?.Endpoint.FriendlyName,
+            });
+        }
+        // Update the live set + count baseline now so the 20Hz tick can't re-add the chip and our
+        // own save's SettingsChanged doesn't trigger a redundant reconcile.
+        _hiddenAppOnDeviceKeys.Add(DeviceHideKey(key, endpointId));
+        _lastHiddenAppsOnDeviceCount = _settings.Current.HiddenAppsOnDevice.Count;
+
+        // Drop only the chip on the matching card; the app stays on every other card.
+        foreach (var card in _allCards)
+        {
+            if (!string.Equals(card.Endpoint.Id, endpointId, StringComparison.OrdinalIgnoreCase)) continue;
+            var removed = false;
+            for (var i = card.Apps.Count - 1; i >= 0; i--)
+            {
+                if (string.Equals(card.Apps[i].Session.IdentityKey, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    card.Apps.RemoveAt(i);
+                    removed = true;
+                }
+            }
+            if (removed) NotifyCardApps(card);
+        }
+
+        _logger.LogInformation("App hidden from chip row on one device: key='{Key}' endpoint='{Endpoint}'", key, endpointId);
         QueueSettingsSave();
     }
 
@@ -1957,6 +2040,13 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         // bound live on the existing card instance.
     }
 
+    private void OnCardCustomisationChanged(DeviceCard card)
+    {
+        UpdateDeviceConfig(card);
+        QueueSettingsSave();
+        // No resync: glyph + accent are bound live on the existing card; visibility is unaffected.
+    }
+
     /// <summary>Removes an endpoint from whichever group's persisted record holds it, disbanding the
     /// group (dropping its record + block-order slot) when that leaves fewer than two members. The
     /// caller persists and resyncs.</summary>
@@ -2068,6 +2158,8 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             Hidden = card.IsHiddenByUser ? true : null,
             Pinned = card.IsPinnedByUser ? true : null,
             VolumeControlsHidden = card.IsVolumeControlsHiddenByUser ? true : null,
+            Glyph = card.CurrentGlyphOverride,
+            AccentColour = card.CurrentAccent is { } c ? Controls.DeviceAccentPalette.ToHex(c) : null,
         };
         if (cfg.IsDefault) map.Remove(card.Endpoint.Id);
         else map[card.Endpoint.Id] = cfg;

--- a/src/Earmark.App/ViewModels/SettingsViewModel.cs
+++ b/src/Earmark.App/ViewModels/SettingsViewModel.cs
@@ -223,7 +223,8 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     /// <see cref="LoadHiddenApps"/> when the manage modal opens, and mutated by unhide / clear.</summary>
     public ObservableCollection<HiddenAppRow> HiddenApps { get; } = new();
 
-    public bool HasHiddenApps => _settings.Current.HiddenApps.Count > 0;
+    private int HiddenAppsTotal => _settings.Current.HiddenApps.Count + _settings.Current.HiddenAppsOnDevice.Count;
+    public bool HasHiddenApps => HiddenAppsTotal > 0;
     public bool NoHiddenApps => !HasHiddenApps;
 
     /// <summary>Card description that reflects how many apps are hidden.</summary>
@@ -231,9 +232,9 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     {
         get
         {
-            var n = _settings.Current.HiddenApps.Count;
+            var n = HiddenAppsTotal;
             return n == 0
-                ? "Apps you've hidden from the device cards with a chip's right-click menu. None hidden yet."
+                ? "Apps you've hidden from the device cards with a chip's right-click menu (everywhere or on one device). None hidden yet."
                 : $"{n} app{(n == 1 ? "" : "s")} hidden from the device cards. Manage to unhide.";
         }
     }
@@ -247,6 +248,10 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         {
             HiddenApps.Add(new HiddenAppRow(app.Key, app.Name));
         }
+        foreach (var app in _settings.Current.HiddenAppsOnDevice)
+        {
+            HiddenApps.Add(new HiddenAppRow(app.Key, app.EndpointId, app.Name, app.DeviceName));
+        }
         RefreshHiddenAppsState();
     }
 
@@ -256,16 +261,25 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     {
         if (row is null) return;
         HiddenApps.Remove(row);
-        Persist(s => s.HiddenApps.RemoveAll(h => string.Equals(h.Key, row.Key, StringComparison.OrdinalIgnoreCase)));
+        if (row.IsPerDevice)
+        {
+            Persist(s => s.HiddenAppsOnDevice.RemoveAll(h =>
+                string.Equals(h.Key, row.Key, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(h.EndpointId, row.EndpointId, StringComparison.OrdinalIgnoreCase)));
+        }
+        else
+        {
+            Persist(s => s.HiddenApps.RemoveAll(h => string.Equals(h.Key, row.Key, StringComparison.OrdinalIgnoreCase)));
+        }
         RefreshHiddenAppsState();
     }
 
-    /// <summary>Unhides every app at once.</summary>
+    /// <summary>Unhides every app at once (both global and per-device hides).</summary>
     public void ClearAllHiddenApps()
     {
-        if (_settings.Current.HiddenApps.Count == 0) return;
+        if (HiddenAppsTotal == 0) return;
         HiddenApps.Clear();
-        Persist(s => s.HiddenApps.Clear());
+        Persist(s => { s.HiddenApps.Clear(); s.HiddenAppsOnDevice.Clear(); });
         RefreshHiddenAppsState();
     }
 
@@ -337,20 +351,38 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 /// <see cref="Detail"/> is the full identity key, shown as muted subtext when it differs.</summary>
 public sealed class HiddenAppRow
 {
+    /// <summary>Global hide (hidden on every device).</summary>
     public HiddenAppRow(string key, string? name)
     {
         Key = key ?? string.Empty;
         Name = string.IsNullOrWhiteSpace(name) ? DeriveName(Key) : name!;
     }
 
+    /// <summary>Per-device hide (hidden on one endpoint only).</summary>
+    public HiddenAppRow(string key, string endpointId, string? name, string? deviceName)
+        : this(key, name)
+    {
+        EndpointId = endpointId ?? string.Empty;
+        _deviceName = string.IsNullOrWhiteSpace(deviceName) ? "this device" : deviceName!;
+    }
+
+    private readonly string? _deviceName;
+
     /// <summary>Match key (the app's identity key) used to remove the entry on unhide.</summary>
     public string Key { get; }
 
+    /// <summary>Endpoint id for a per-device hide; empty for a global hide.</summary>
+    public string EndpointId { get; } = string.Empty;
+
+    public bool IsPerDevice => !string.IsNullOrEmpty(EndpointId);
+
     public string Name { get; }
 
-    public string Detail => Key;
+    /// <summary>Muted subtext: the hidden-on device for a per-device row, else the identity key.</summary>
+    public string Detail => IsPerDevice ? $"on {_deviceName} - {Key}" : Key;
 
-    public bool HasDetail => !string.IsNullOrEmpty(Key) && !string.Equals(Key, Name, StringComparison.OrdinalIgnoreCase);
+    public bool HasDetail => IsPerDevice ||
+        (!string.IsNullOrEmpty(Key) && !string.Equals(Key, Name, StringComparison.OrdinalIgnoreCase));
 
     private static string DeriveName(string key)
     {

--- a/src/Earmark.App/Views/HomePage.xaml
+++ b/src/Earmark.App/Views/HomePage.xaml
@@ -77,6 +77,16 @@
                                 <FontIcon Glyph="{x:Bind VolumeControlsToggleGlyph, Mode=OneWay}" />
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
+                        <!-- Customise the card glyph + accent colour. Opens a picker flyout anchored
+                             on the card; built in code-behind so the heavy ColorPicker isn't
+                             instantiated per card. -->
+                        <MenuFlyoutItem Text="Customise…"
+                                        Click="OnCustomiseClicked"
+                                        Tag="{x:Bind}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE790;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
                         <!-- Ungroup device (pull just this device out of its group) sits in its own
                              section between the device options above and the group-wide actions below,
                              all shown only for a grouped device. -->
@@ -159,7 +169,6 @@
                                         CornerRadius="{StaticResource CardCornerRadius}"
                                         Tag="{x:Bind}"
                                         IsEnabled="{x:Bind IsMuteToggleEnabled, Mode=OneWay}"
-                                        IsHitTestVisible="{x:Bind ShowVolumeControls, Mode=OneWay}"
                                         Click="OnMuteToggleClicked"
                                         ToolTipService.ToolTip="{x:Bind MuteTooltip, Mode=OneWay}">
                                     <!-- Transparent in every state but hover/press, where a faint white
@@ -510,13 +519,17 @@
                                              mirrors the card's ContextFlyout above - keep the two in sync. -->
                                         <Border.ContextFlyout>
                                             <MenuFlyout Opening="OnAppChipFlyoutOpening">
-                                                <MenuFlyoutItem Text="Hide this app"
-                                                                Command="{x:Bind HideCommand}"
-                                                                ToolTipService.ToolTip="Permanently hide this app's chip from every device. Unhide it from Settings &#x2192; App indicators.">
-                                                    <MenuFlyoutItem.Icon>
+                                                <MenuFlyoutSubItem Text="Hide this app">
+                                                    <MenuFlyoutSubItem.Icon>
                                                         <FontIcon Glyph="&#xED1A;" />
-                                                    </MenuFlyoutItem.Icon>
-                                                </MenuFlyoutItem>
+                                                    </MenuFlyoutSubItem.Icon>
+                                                    <MenuFlyoutItem Text="On this device"
+                                                                    Command="{x:Bind HideOnDeviceCommand}"
+                                                                    ToolTipService.ToolTip="Hide this app's chip on this device only; it stays on other devices. Unhide it from Settings &#x2192; App indicators." />
+                                                    <MenuFlyoutItem Text="Everywhere"
+                                                                    Command="{x:Bind HideCommand}"
+                                                                    ToolTipService.ToolTip="Permanently hide this app's chip from every device. Unhide it from Settings &#x2192; App indicators." />
+                                                </MenuFlyoutSubItem>
                                                 <!-- Close = graceful WM_CLOSE (the app can save / prompt). Disabled and
                                                      relabelled when the app is elevated (a disabled item can't show a
                                                      tooltip, so the reason lives in the text). Hidden for System Sounds

--- a/src/Earmark.App/Views/HomePage.xaml.cs
+++ b/src/Earmark.App/Views/HomePage.xaml.cs
@@ -215,6 +215,115 @@ public sealed partial class HomePage : Page
         }
     }
 
+    private void OnCustomiseClicked(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { Tag: DeviceCard card }) return;
+        // Defer so the context MenuFlyout finishes dismissing before the dialog opens.
+        DispatcherQueue.TryEnqueue(async () =>
+        {
+            try
+            {
+                var dialog = BuildCustomiseDialog(card);
+                dialog.XamlRoot = XamlRoot;
+                await dialog.ShowAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Customise: dialog threw");
+            }
+        });
+    }
+
+    private static ContentDialog BuildCustomiseDialog(DeviceCard card)
+    {
+        var root = new StackPanel { Spacing = 12, MinWidth = 320 };
+
+        root.Children.Add(new TextBlock
+        {
+            Text = "Glyph",
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+        });
+
+        // Glyph picker: a wrap of selectable buttons, single-select. The current selection (or
+        // Auto when no override) gets the accent outline. Built by hand so we can toggle the
+        // selected outline and apply live.
+        var glyphHost = new WrapPanel { HorizontalSpacing = 6, VerticalSpacing = 6 };
+        var glyphButtons = new List<Button>();
+        foreach (var choice in DeviceGlyphMapper.GlyphChoices)
+        {
+            var btn = new Button
+            {
+                Width = 40,
+                Height = 40,
+                Padding = new Thickness(0),
+                Tag = choice,
+            };
+            if (choice.IsAuto)
+            {
+                btn.Content = new TextBlock
+                {
+                    Text = "Auto",
+                    FontSize = 11,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                };
+            }
+            else
+            {
+                btn.Content = new FontIcon { Glyph = choice.Glyph, FontSize = 20 };
+            }
+            ToolTipService.SetToolTip(btn, choice.Label);
+            glyphHost.Children.Add(btn);
+            glyphButtons.Add(btn);
+        }
+
+        void RefreshGlyphSelection()
+        {
+            var current = card.CurrentGlyphOverride;
+            foreach (var btn in glyphButtons)
+            {
+                var choice = (GlyphChoice)btn.Tag;
+                var selected = choice.IsAuto ? current is null : choice.Glyph == current;
+                btn.BorderThickness = new Thickness(selected ? 2 : 1);
+                btn.BorderBrush = selected
+                    ? (Brush)Application.Current.Resources["AccentFillColorDefaultBrush"]
+                    : (Brush)Application.Current.Resources["ControlStrokeColorDefaultBrush"];
+            }
+        }
+
+        foreach (var btn in glyphButtons)
+        {
+            btn.Click += (_, _) =>
+            {
+                var choice = (GlyphChoice)btn.Tag;
+                card.SetUserCustomisation(choice.Glyph, card.CurrentAccent);
+                RefreshGlyphSelection();
+            };
+        }
+        RefreshGlyphSelection();
+        root.Children.Add(glyphHost);
+
+        // Colour picker (shared control). Auto allowed so the user can clear the colour override.
+        var colourPicker = new Controls.ColourSwatchPicker
+        {
+            AllowAuto = true,
+            SelectedColour = card.CurrentAccent,
+        };
+        colourPicker.RegisterPropertyChangedCallback(
+            Controls.ColourSwatchPicker.SelectedColourProperty,
+            (_, _) => card.SetUserCustomisation(card.CurrentGlyphOverride, colourPicker.SelectedColour));
+        root.Children.Add(colourPicker);
+
+        return new ContentDialog
+        {
+            Title = $"Customise {card.DeviceNameOnly}",
+            // Changes apply live behind the dialog; a single close button dismisses it.
+            Content = new ScrollViewer { Content = root, VerticalScrollBarVisibility = ScrollBarVisibility.Auto },
+            CloseButtonText = "Done",
+            DefaultButton = ContentDialogButton.Close,
+        };
+    }
+
     private void OnGroupTitleKeyDown(object sender, KeyRoutedEventArgs e)
     {
         if (e.Key != VirtualKey.Enter) return;

--- a/src/Earmark.App/Views/SettingsPage.xaml
+++ b/src/Earmark.App/Views/SettingsPage.xaml
@@ -5,6 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:vm="using:Earmark.App.ViewModels"
     xmlns:ctrl="using:CommunityToolkit.WinUI.Controls"
+    xmlns:controls="using:Earmark.App.Controls"
     xmlns:ui="using:Windows.UI"
     Background="Transparent">
 
@@ -151,38 +152,8 @@
                                 </StackPanel>
                                 <Button.Flyout>
                                     <Flyout>
-                                        <StackPanel Spacing="{StaticResource SpacingMedium}" Width="296">
-                                            <TextBlock Text="Quick colours"
-                                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                            <ItemsControl ItemsSource="{x:Bind MeterSwatches}">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <StackPanel Orientation="Horizontal" Spacing="{StaticResource SpacingXSmall}" />
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate x:DataType="ui:Color">
-                                                        <Button Width="28" Height="28"
-                                                                Padding="0"
-                                                                Click="OnMeterSwatchClick"
-                                                                Tag="{x:Bind}"
-                                                                HorizontalContentAlignment="Stretch"
-                                                                VerticalContentAlignment="Stretch">
-                                                            <Border CornerRadius="{ThemeResource ControlCornerRadius}"
-                                                                    Background="{x:Bind Converter={StaticResource ColorToBrushConverter}}" />
-                                                        </Button>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
-                                            <ColorPicker x:Name="MeterColorPicker"
-                                                         Color="{x:Bind ViewModel.PeakMeterSingleColour, Mode=TwoWay}"
-                                                         ColorSpectrumShape="Ring"
-                                                         IsAlphaEnabled="False"
-                                                         IsMoreButtonVisible="True"
-                                                         IsColorSliderVisible="True"
-                                                         IsColorChannelTextInputVisible="False"
-                                                         IsHexInputVisible="True" />
+                                        <StackPanel Spacing="{StaticResource SpacingMedium}">
+                                            <controls:ColourSwatchPicker x:Name="MeterColourPicker" />
                                             <Button Content="Reset to default"
                                                     Click="OnResetMeterColour"
                                                     HorizontalAlignment="Right" />

--- a/src/Earmark.App/Views/SettingsPage.xaml.cs
+++ b/src/Earmark.App/Views/SettingsPage.xaml.cs
@@ -11,25 +11,21 @@ namespace Earmark.App.Views;
 
 public sealed partial class SettingsPage : Page
 {
-    // Current default green first, then a distinct spread of Windows/Fluent accent hues (one each
-    // of teal, blue, purple, magenta, red, orange, gold) for quick picks above the colour wheel.
-    private static readonly Color[] FluentSwatches =
-    {
-        Color.FromArgb(0xFF, 0x00, 0xB7, 0xC3), // teal
-        Color.FromArgb(0xFF, 0x00, 0x78, 0xD4), // blue
-        Color.FromArgb(0xFF, 0x87, 0x64, 0xB8), // purple
-        Color.FromArgb(0xFF, 0xE3, 0x00, 0x8C), // magenta
-        Color.FromArgb(0xFF, 0xE8, 0x11, 0x23), // red
-        Color.FromArgb(0xFF, 0xF7, 0x63, 0x0C), // orange
-        Color.FromArgb(0xFF, 0xFF, 0xB9, 0x00), // gold
-    };
+    private bool _syncingMeterColour;
 
     public SettingsPage(SettingsViewModel viewModel, AboutViewModel about)
     {
         ViewModel = viewModel;
         About = about;
-        MeterSwatches = BuildMeterSwatches();
         InitializeComponent();
+
+        // Seed the shared colour picker from the VM and keep the two in sync. The picker's
+        // SelectedColour is nullable; the peak-meter colour never goes null (no Auto), so the
+        // guard below only forwards real colours.
+        MeterColourPicker.SelectedColour = ViewModel.PeakMeterSingleColour;
+        MeterColourPicker.RegisterPropertyChangedCallback(
+            Controls.ColourSwatchPicker.SelectedColourProperty, OnMeterPickerColourChanged);
+        ViewModel.PropertyChanged += OnSettingsViewModelPropertyChanged;
 
         // The hidden-apps count can change from the Devices page while this singleton page is
         // off-screen, so refresh its card description each time the page is shown.
@@ -40,22 +36,18 @@ public sealed partial class SettingsPage : Page
 
     public AboutViewModel About { get; }
 
-    /// <summary>Quick-pick colours bound by the swatch strip in the bar-colour flyout.</summary>
-    public IReadOnlyList<Color> MeterSwatches { get; }
-
-    private static List<Color> BuildMeterSwatches()
+    private void OnMeterPickerColourChanged(DependencyObject sender, DependencyProperty dp)
     {
-        var colours = new List<Color> { PeakMeterOptions.DefaultColour };
-        colours.AddRange(FluentSwatches);
-        return colours;
+        if (_syncingMeterColour || MeterColourPicker.SelectedColour is not Color colour) return;
+        ViewModel.PeakMeterSingleColour = colour;
     }
 
-    private void OnMeterSwatchClick(object sender, RoutedEventArgs e)
+    private void OnSettingsViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (sender is FrameworkElement { Tag: Color colour })
-        {
-            ViewModel.PeakMeterSingleColour = colour;
-        }
+        if (e.PropertyName != nameof(SettingsViewModel.PeakMeterSingleColour)) return;
+        _syncingMeterColour = true;
+        MeterColourPicker.SelectedColour = ViewModel.PeakMeterSingleColour;
+        _syncingMeterColour = false;
     }
 
     private void OnResetMeterColour(object sender, RoutedEventArgs e) => ViewModel.ResetPeakMeterColour();


### PR DESCRIPTION
Adds a "Customise…" entry to each device card's right-click menu, opening a modal to override the card glyph and accent tile colour per device. Overrides persist in settings.json keyed by endpoint id and win over the auto-derived glyph / Wave Link accent; "Auto" on either axis clears that override. The auto Wave Link accent now snaps to the nearest palette colour as its resting state. Adds a shared ColourSwatchPicker control (bright Fluent accent palette + custom wheel) reused by the Settings peak-meter colour picker.

This PR also carries the parallel "hide app on a single device" feature and a small mute fix.

---

feat: hide an app's chip on a single device from its chip context menu

fix: allow click-to-mute on the device icon when volume controls are hidden