### PR TITLE
ci: fix WACK being skipped on the release-please PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -347,6 +347,10 @@ jobs:
   wack:
     name: WACK (${{ matrix.platform }})
     needs: [build-msix]
+    # build-msix runs via `if: always()` (it overrides the skipped release-please job on PRs). Without
+    # an explicit condition here, that upstream skip propagates through and skips WACK too. Gate on
+    # build-msix's actual result so WACK runs whenever the package was built, and skips with it.
+    if: always() && needs.build-msix.result == 'success'
     runs-on: windows-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

After #61's package-build gating, WACK is skipped on the release-please PR (and shows the un-expanded `WACK (${{ matrix.platform }})` name, i.e. a job-level skip before the matrix expands).

## Cause

`build-msix` now `needs: [release-please]` and runs via `if: always()` to override release-please being skipped on PRs. WACK `needs: [build-msix]` but had **no** `if`, so the upstream skip propagated transitively through `build-msix` and skipped WACK. `Pre-Release` was unaffected because it already uses `always()`.

## Fix

Gate WACK on build-msix's actual result:

```yaml
if: always() && needs.build-msix.result == 'success'
```

So WACK runs whenever the package was built (PRs, release-creating pushes, force_build) and skips cleanly when build-msix is skipped (ordinary pushes to main).

## Testing

- [x] YAML parses.
- [ ] WACK (x64/ARM64) runs (not skips) on this PR, and the job name renders correctly.

---

ci: stop WACK being skipped by the release-please skip propagation
