### PR TITLE
feat: compact card density and Quick Controls display options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,1 @@
-See [AGENTS.md](./AGENTS.md) for the full project instructions (layout, build/run pattern, rule schema, commit/PR conventions). Treat AGENTS.md as the authoritative source.
-ALWAYS READ THIS INSTANTLY.
+@agents.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 An audio companion for Windows, built around a regex-driven rules engine. Routing rules pin each app to the device you want (a browser to your media DAC, Discord onto your headset mic, the system default to a specific endpoint) and keep it there across reboots, app updates, and driver reinstalls. Around that sits a live per-device mixer, now-playing with media controls, and quick access from the tray or a global shortcut. Like Volume Mixer's per-app device picker, but pattern-driven and persistent. A full control centre.
 
-[![Download from GitHub Releases](https://img.shields.io/github/v/release/hoobio/earmark?label=Download&logo=github&style=for-the-badge&color=181717)](https://github.com/hoobio/earmark/releases/latest)
+[![Get it from Microsoft Store](https://img.shields.io/badge/Microsoft%20Store-Install-0078D4?style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAfCAYAAACGVs+MAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH6QsSCzAeWUOqngAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAyNS0xMS0xOFQxMTo0ODozMCswMDowMGw9ckYAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMjUtMTEtMThUMTE6NDg6MzArMDA6MDAdYMr6AAABh2lUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSfvu78nIGlkPSdXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQnPz4NCjx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iPjxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+PHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9InV1aWQ6ZmFmNWJkZDUtYmEzZC0xMWRhLWFkMzEtZDMzZDc1MTgyZjFiIiB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+PHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj48L3JkZjpEZXNjcmlwdGlvbj48L3JkZjpSREY+PC94OnhtcG1ldGE+DQo8P3hwYWNrZXQgZW5kPSd3Jz8+LJSYCwAAA+VJREFUWEe9lk+IG1Ucx7+/9yaZJJttdrfZuGpbXIIBsSAIPRU8CBa9qRcVRPQoLD15UPBW8VCqV716KuTmpUjFIt6EQLEeKouwsGx2kh15k2xsk8nMez8PSdjZl2wm/bN+4HvIm+/75fve+71hgEekXq9nlVJXlVL3u90uB0HAQRD8qZTaqtfrWdufBtkD89jZ2XlpbW3tZyFEod/vf9Pr9W7ncrlzruu+k81mP2TmplLqyubm5n177kksHKDT6awS0d/MfHdlZeVKo9FYrtVq14gor7W+0+l0Dkql0ldCiKoxphaGobuxsdG26zw2nud9p5RSAGh3d/fS4eHhIAiC7/f29s5OPI1Go9Dtdnv7+/vX2+32K57nvXe8ymOyvb3ttlqtB81mcwsAfN/vHBwc/GD7AKDZbH7heV7PGOO2Wq1bvu8/Z3uSCHtgFsVicUNKWWDm2+12+00pZanX6121fQAgpfzVcZyi7/sZABxF0Qe2J8lCAaIoiowxICLFzK8NBoM/qtVq1/YBgDGmq7VGpVIJATwkoldtTxLyPO+iPWgjpTzPzLe01m8B+ISIXgTwke0bc5GIbhLRZWa+xswSwJZtmkC+77M9aMPMMMZACAFmBjNDiJM3L+kFACIC0ewLJyYF58lmUnCWTsKuORG1Wq3pf/gfWSAAAxkXEBJI7gYROB5CaoIUWSSLEADDGpoHqe+69AAkQEEb1H8AJM/daODMOh7mNfpD/9j2MxhZsYRi5nkwzNGcGaQEIHB+Cbkbn8L5/SdwYfnoSa8D+fF13Ln8D37763PknaNZoQZqq2/g7eqPGOreaBdP4ORWTsJmtGJbzGAwmEenc0wpK5+wWAASox6wRQQCgQjTWrD0Yq5TZLEAcQQMB8AwTGgA0hoGMWKDKWkept4ALBSADTJnn4F7vgr33AtHulAFLReRE2WsFWpYtVTMboKh7WpTpNwCQBBw0DcYxHx8QQyccR2syAAcBYkHY0QBnHkWSGnGuQEIwLIDvHvXxS8tCWQSD4eEz14u4uulL4Gdb4HENYQGhiuvQ1XrIP3vk1/DYWwQRXpKsQHAQ0D3p8Sm/5R6AICkcS1Lo8lianwkaZeZyUIBTpOFAkRm3EuWYgbA8eg3J2QA4sguM5PUAAxg3QUqeUYll1CeUXIMjCzBuBWYTEJuBdpZn9t8E+beAoyPc2AAPcOVEYQshsCs1ZIEUy41RGoAjJtQkFWLRqE0C9DMhjMAL/AiUkpxGIZzP6dOA2aG67oQYRjeK5fLAOZ/6z1NAUC5XEYURfdIKXXBcZybcRxfCsNQEFHqkTwJzEyu6xohRMMY8/5/UhUwwGPTYBoAAAAASUVORK5CYII=)](https://apps.microsoft.com/detail/9N27KG5M9W9B)
+&nbsp;&nbsp;&nbsp;&nbsp;
+[![Download from GitHub Releases](https://img.shields.io/github/v/release/hoobio/earmark?label=Download%20from%20GitHub&logo=github&style=for-the-badge&color=181717)](https://github.com/hoobio/earmark/releases/latest)
+&nbsp;&nbsp;&nbsp;&nbsp;
+[![Donate with PayPal](https://img.shields.io/badge/Donate-PayPal-003087?style=for-the-badge&logo=paypal)](https://www.paypal.com/donate/?hosted_button_id=SWG4G7VH3ZFQN)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/hoobio/earmark?style=social)](https://github.com/hoobio/earmark/stargazers)
@@ -50,6 +54,12 @@ An audio companion for Windows, built around a regex-driven rules engine. Routin
 No external CLIs, no service install, no admin rights.
 
 ## Installation
+
+### Microsoft Store
+
+**[Get it from the Microsoft Store](https://apps.microsoft.com/detail/9N27KG5M9W9B)** for automatic updates.
+
+> The Store version may lag behind GitHub Releases due to Microsoft's certification process. Install from GitHub if you need the latest version immediately.
 
 ### GitHub Releases
 

--- a/docs/adr/compact-card-density.md
+++ b/docs/adr/compact-card-density.md
@@ -1,0 +1,73 @@
+# Decision record: per-view card display options (compact density + Quick Controls overrides)
+
+**Status:** Accepted (2026-06-07). Implemented in `feat/compact-cards` (`PeakMeterOptions`, `CardPresentation`, `DeviceCardView`, `HomeViewModel`, `AppSettings`).
+
+Records how a device card renders at a different density and feature set in each window without duplicating the card, why compact mode is one input among the per-view options, and the slider-centring gotcha the compact row hit.
+
+## Context
+
+Device cards (`DeviceCardView`) render in two windows from the **same** view-models: the Devices page (`HomePage`) and the Quick Controls overlay (`QuickControlsWindow`). There is one `DeviceCard` per device and one `NowPlayingStrip` per playing app; both windows bind those same instances. This single-instance design is why volume, mute, the 20 Hz peak meters, and now-playing state are automatically identical in both windows (same object, nothing to sync).
+
+Two needs pulled against that:
+
+1. **Compact density** had to tighten many independent measurements at once (card padding, section spacing, icon tile, volume + meter height, now-playing strip layout, rule chips) and update live on toggle.
+2. **Quick Controls had to diverge from the Devices page**: render compact, drop the rules section, drop the header badges, drop the section dividers, keep now-playing - while the main window kept the user's roomy Devices layout. Driving the one shared options object compacts the main window too whenever it's visible behind the overlay (a visible glitch the user rejected).
+
+## Decision
+
+**Card display is resolved per view through a lightweight `CardPresentation(card, options)` projection. The card and strip instances stay shared (live state identical); only a `PeakMeterOptions` instance diverges per window.**
+
+- `DeviceCardView` takes an `Options` dependency property. Unset (the main window) falls back to `card.MeterOptions`, the global options object - so the Devices page is byte-for-byte unchanged. Quick Controls sets `Options="{x:Bind QuickMeterOptions}"`.
+- From `Card` + `Options` the view builds a `CardPresentation`. The XAML binds it for two things:
+  - **display geometry** (`Presentation.Options.X`: padding, spacing, icon tile, volume/meter heights, the now-playing strip layout, rule-chip metrics, and the `CompactCards` flag), and
+  - **combine-with-data visibility** (`Presentation.ShowRulesSection`, `ShowNowPlaying`, the `ShowNormalBadges`/`ShowCompactBadges` pair, the section dividers) which fold one option (`ShowRules` / `ShowNowPlaying` / `ShowDeviceBadges` / `ShowCardDividers` / `CompactCards`) with card data.
+- The **data-template gap** is closed by `CardPresentation.NowPlayingStrips`: it mirrors `DeviceCard.NowPlayingStrips` as `NowPlayingStripView(Strip, Options)` records (in place, via `CollectionChanged`). Each strip's data template binds `Strip.X` for live state and `Options.X` for geometry, so the strip renders at the host window's density even though the template can't reach the host control's DP. The expanded rule chips use the same trick (`RuleSummary.Options`).
+
+This is a refinement of the per-view option the first draft of this ADR rejected (then "approach 2"). What made it viable is that `CardPresentation` holds **no live state** - only a reference to the shared card/strip plus the view's options, recomputing pure styling flags on `PropertyChanged`. So it never becomes "approach 3" (separate card/strip instances + a mirroring layer): live state stays single-instance and identical across windows; only styling diverges.
+
+### Compact density
+
+`CompactCards` on `PeakMeterOptions` drives every compact geometry getter (`CardContentPadding`, `CardSectionSpacing`, `IconTileSize`, `VolumeRowHeight`, `MeterTotalHeight`, `VolumeSliderMargin`, `NowPlayingStripPadding`, the transport sizes, `RuleChipPadding`, the `ShowNormalBadges`/`ShowCompactBadges` pair, etc.). Every getter returns the **roomy** value when `CompactCards` is false, so the non-compact layout never shifts. `OnCompactCardsChanged` re-raises them all, so a toggle re-flows live with no card rebuild.
+
+- The Devices page is fed by `AppSettings.CompactCards` (default false), toggled from Settings and the Devices backdrop menu, mirrored onto the global options by `HomeViewModel.SyncMeterOptions`.
+- Quick Controls is fed by its own `QuickControlsCompact` (default true), independent of the page.
+
+### Quick Controls overrides
+
+Quick Controls is its own configurable view. `HomeViewModel.SyncQuickMeterOptions` builds `QuickMeterOptions` by mirroring the global options, then applying five overrides that win for the overlay only (the main window binds the global object, QC binds its own, so the page is never touched):
+
+| Setting | Default | Effect in QC |
+|---|---|---|
+| `QuickControlsCompact` | true | Compact density |
+| `QuickControlsShowNowPlaying` | true | Keep the now-playing strip |
+| `QuickControlsShowRules` | false | Drop the rules section (overlay is for control, not rule editing) |
+| `QuickControlsShowDeviceBadges` | false | Drop the flow / Default / Communications pills |
+| `QuickControlsShowDividers` | false | Drop the hairline section dividers |
+
+Defaults suit a dense, glanceable overlay. A Quick Controls card's only context menu is a single **Settings** item: it restores the main window, navigates to Settings, and reveals (expands + scrolls to) the Quick Controls section. Configuration lives in the app, not the overlay.
+
+## Tradeoffs
+
+| Concern | This design | Alternative |
+|---|---|---|
+| Per-window divergence | `CardPresentation` projection over shared instances | Separate card/strip instances + a live-state mirroring layer |
+| Live state across windows | Single instance, identical, nothing to sync | Mirroring layer (volume/mute/meters/now-playing/seek/connection) |
+| Live update on toggle | `OnPropertyChanged` re-raise, no rebuild | Card rebuild on toggle (loses transient UI state) |
+| Data-templated scopes (strip, rule chips) | `NowPlayingStripView` / `RuleSummary.Options` carry the view's options | Unreachable from a host-view DP (half-compact card) |
+| Number of compact knobs | One `CompactCards` flag per options object | Per-card flags (more state, more sync) |
+
+## Consequences
+
+- A new display-dependent measurement is added as a getter on `PeakMeterOptions` and re-raised in `OnCompactCardsChanged` (or the relevant `On…Changed`). Keep the roomy branch returning the pre-compact value so normal layout never shifts.
+- A new combine-with-data flag is added to `CardPresentation` (option folded with card data) and re-raised in `RaiseAll`, then bound as `Presentation.X`.
+- A new per-window QC override is a setting on `AppSettings` (mirrored in `SyncQuickMeterOptions`) plus a card under the Quick Controls settings expander. It must read from `QuickMeterOptions`, never the global, so the main window is untouched.
+- Live state stays single-instance. If a future need can't be expressed as a styling option (it needs genuinely different live data per window), that is the trigger to give QC its own projected card instances with a sync layer - and this ADR is where that cost is documented.
+
+### Slider height gotcha (volume + now-playing seek)
+
+The WinUI `Slider` template forces a ~32 px min body (`SliderHorizontalHeight`) with the thumb sitting below the control's geometric centre. Two non-fixes we tried and rejected:
+
+- Overriding the `SliderHorizontalHeight` resource in `Slider.Resources` does **nothing** (the template doesn't pick up the instance override).
+- A `MaxHeight` clamp shrinks the control but does **not** re-centre the thumb, so it clips.
+
+What works: keep the slider its natural size and place it (centre-aligned) inside a **fixed-height, non-clipping host**; the slim row is the host's height, the slider overflows it invisibly (transparent track), and a small DIP-based negative top margin lifts the low-sitting thumb back onto the host centre. The compact volume row and the now-playing seek host both use this.

--- a/src/Earmark.App/App.xaml.cs
+++ b/src/Earmark.App/App.xaml.cs
@@ -167,6 +167,20 @@ public partial class App : Application
         chrome?.RestoreWindow();
     }
 
+    /// <summary>Restores the main window, navigates to Settings, and reveals the Quick Controls section.
+    /// Invoked from the Quick Controls overlay's "Settings" context-menu item (cards and group titles).</summary>
+    public void OpenQuickControlsSettings()
+    {
+        if (_host is null)
+        {
+            return;
+        }
+
+        RestoreFromBackground();
+        _host.Services.GetRequiredService<MainWindow>().NavigateByTag("Settings");
+        _host.Services.GetRequiredService<SettingsPage>().RevealQuickControls();
+    }
+
     public void DisposeHost()
     {
         if (_host is null)

--- a/src/Earmark.App/Controls/BlockWrapLayout.cs
+++ b/src/Earmark.App/Controls/BlockWrapLayout.cs
@@ -195,7 +195,9 @@ public sealed class BlockWrapLayout : VirtualizingLayout
 
         for (var slot = 0; slot < display.Length; slot++)
         {
-            context.GetOrCreateElementAt(display[slot]).Arrange(slotRects[slot]);
+            var element = context.GetOrCreateElementAt(display[slot]);
+            element.Arrange(slotRects[slot]);
+            ReorderElevation.TrackAndElevate(element, slotRects[slot]);
         }
 
         return new Size(finalSize.Width, totalHeight);

--- a/src/Earmark.App/Controls/ChannelPeakMeter.xaml.cs
+++ b/src/Earmark.App/Controls/ChannelPeakMeter.xaml.cs
@@ -120,6 +120,18 @@ public sealed partial class ChannelPeakMeter : UserControl
         set => SetValue(BarHeightOverrideProperty, value);
     }
 
+    /// <summary>When &gt; 0, overrides the total stacked-meter height (default 20) that the channel bars
+    /// divide between them - used by compact cards to slim the meter. Ignored if
+    /// <see cref="BarHeightOverride"/> is set (the app-chip underbar path).</summary>
+    public static readonly DependencyProperty TotalHeightOverrideProperty = DependencyProperty.Register(
+        nameof(TotalHeightOverride), typeof(double), typeof(ChannelPeakMeter), new PropertyMetadata(0.0, OnShapeChanged));
+
+    public double TotalHeightOverride
+    {
+        get => (double)GetValue(TotalHeightOverrideProperty);
+        set => SetValue(TotalHeightOverrideProperty, value);
+    }
+
     public static readonly DependencyProperty ShowHoldProperty = DependencyProperty.Register(
         nameof(ShowHold), typeof(bool), typeof(ChannelPeakMeter), new PropertyMetadata(true, OnShapeChanged));
 
@@ -187,9 +199,10 @@ public sealed partial class ChannelPeakMeter : UserControl
             }
         }
 
+        var totalHeight = TotalHeightOverride > 0 ? TotalHeightOverride : TotalMeterHeight;
         var barHeight = BarHeightOverride > 0
             ? BarHeightOverride
-            : TotalMeterHeight / count;
+            : totalHeight / count;
 
         // Rounded ends on the outer corners only so the stack reads as one block; radius =
         // half the stack height for pill ends matching the old single bar.

--- a/src/Earmark.App/Controls/DeviceCardView.xaml
+++ b/src/Earmark.App/Controls/DeviceCardView.xaml
@@ -56,7 +56,7 @@
              every layer shares an identical corner: rounding each layer on its own left the acrylic's
              corner anti-aliasing a hair short of the art's, leaking bright art pixels at the corners. -->
         <Border CornerRadius="{StaticResource CardCornerRadius}"
-                Visibility="{x:Bind Card.ShowCardBackground, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                Visibility="{x:Bind Presentation.ShowCardBackground, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Grid>
                 <controls:CrossfadeImage Source="{x:Bind Card.PrimaryNowPlaying.BackdropSource, Mode=OneWay}"
                                          Stretch="UniformToFill" />
@@ -76,7 +76,7 @@
         <Border Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}"
                 CornerRadius="{StaticResource CardCornerRadius}"
                 Visibility="{x:Bind Card.IsMuted, Mode=OneWay}" />
-        <StackPanel x:Name="SectionStack" Spacing="{x:Bind Card.CardSectionSpacing, Mode=OneWay}" Margin="{x:Bind Card.CardContentPadding, Mode=OneWay}">
+        <StackPanel x:Name="SectionStack" Spacing="{x:Bind Presentation.Options.CardSectionSpacing, Mode=OneWay}" Margin="{x:Bind Presentation.Options.CardContentPadding, Mode=OneWay}">
             <!-- Header: mute toggle (icon) + name + chips + (Bluetooth) connect/disconnect. Wrapped so
                  compact can hoist the pills to a full-width row below the icon/name (see end of stack). -->
             <StackPanel Spacing="4">
@@ -90,14 +90,14 @@
                 <Border Grid.Column="0"
                         Background="Transparent"
                         ToolTipService.ToolTip="{x:Bind Card.MuteTooltip, Mode=OneWay}">
-                    <Grid Width="{x:Bind Card.IconTileSize, Mode=OneWay}" Height="{x:Bind Card.IconTileSize, Mode=OneWay}">
+                    <Grid Width="{x:Bind Presentation.Options.IconTileSize, Mode=OneWay}" Height="{x:Bind Presentation.Options.IconTileSize, Mode=OneWay}">
                         <Border CornerRadius="{StaticResource CardCornerRadius}"
                                 Background="{ThemeResource SubtleFillColorSecondaryBrush}"
                                 Visibility="{x:Bind Card.ShowDefaultTile, Mode=OneWay}" />
                         <Border CornerRadius="{StaticResource CardCornerRadius}"
                                 Background="{x:Bind Card.WaveLinkTileBrush, Mode=OneWay}"
                                 Visibility="{x:Bind Card.ShowAccentTile, Mode=OneWay}" />
-                        <Button Width="{x:Bind Card.IconTileSize, Mode=OneWay}" Height="{x:Bind Card.IconTileSize, Mode=OneWay}"
+                        <Button Width="{x:Bind Presentation.Options.IconTileSize, Mode=OneWay}" Height="{x:Bind Presentation.Options.IconTileSize, Mode=OneWay}"
                                 Padding="0"
                                 Background="Transparent"
                                 BorderBrush="Transparent"
@@ -117,19 +117,19 @@
                             </Button.Resources>
                             <Grid>
                                 <FontIcon Glyph="{x:Bind Card.Glyph, Mode=OneWay}"
-                                          FontSize="{x:Bind Card.IconGlyphSize, Mode=OneWay}"
+                                          FontSize="{x:Bind Presentation.Options.IconGlyphSize, Mode=OneWay}"
                                           Visibility="{x:Bind Card.GlyphOnAccent, Mode=OneWay}"
                                           Foreground="{x:Bind Card.GlyphContrastBrush, Mode=OneWay}" />
                                 <FontIcon Glyph="{x:Bind Card.Glyph, Mode=OneWay}"
-                                          FontSize="{x:Bind Card.IconGlyphSize, Mode=OneWay}"
+                                          FontSize="{x:Bind Presentation.Options.IconGlyphSize, Mode=OneWay}"
                                           Visibility="{x:Bind Card.GlyphNormalThemed, Mode=OneWay}"
                                           Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                                 <FontIcon Glyph="{x:Bind Card.Glyph, Mode=OneWay}"
-                                          FontSize="{x:Bind Card.IconGlyphSize, Mode=OneWay}"
+                                          FontSize="{x:Bind Presentation.Options.IconGlyphSize, Mode=OneWay}"
                                           Visibility="{x:Bind Card.GlyphMutedThemed, Mode=OneWay}"
                                           Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
                                 <Image Source="{x:Bind Card.WaveLinkIconSource, Mode=OneWay}"
-                                       Width="{x:Bind Card.WaveLinkIconSize, Mode=OneWay}" Height="{x:Bind Card.WaveLinkIconSize, Mode=OneWay}"
+                                       Width="{x:Bind Presentation.Options.WaveLinkIconSize, Mode=OneWay}" Height="{x:Bind Presentation.Options.WaveLinkIconSize, Mode=OneWay}"
                                        Visibility="{x:Bind Card.ShowWaveLinkIcon, Mode=OneWay}" />
                             </Grid>
                         </Button>
@@ -185,7 +185,7 @@
                     <StackPanel Orientation="Horizontal"
                                 Spacing="6"
                                 Margin="-8,4,0,0"
-                                Visibility="{x:Bind Card.ShowNormalBadges, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                Visibility="{x:Bind Presentation.ShowNormalBadges, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <Border Padding="8,2"
                                 VerticalAlignment="Center"
                                 Visibility="{x:Bind Card.ShowFlowLabel, Mode=OneWay}">
@@ -239,7 +239,7 @@
                  sync. -->
             <StackPanel Orientation="Horizontal"
                         Spacing="6"
-                        Visibility="{x:Bind Card.ShowCompactBadges, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        Visibility="{x:Bind Presentation.ShowCompactBadges, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Border Padding="0,2,8,2"
                         VerticalAlignment="Center"
                         Visibility="{x:Bind Card.ShowFlowLabel, Mode=OneWay}">
@@ -270,26 +270,26 @@
             <!-- Volume row: peak meter behind a transparent-track slider, or a plain slider when the
                  meter is Off. Collapses entirely only when both slider and meter are hidden. -->
             <Grid ColumnSpacing="{StaticResource SpacingSmall}"
-                  Visibility="{x:Bind Card.ShowVolumeRow, Mode=OneWay}">
+                  Visibility="{x:Bind Presentation.ShowVolumeRow, Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <Grid Grid.Column="0" Height="{x:Bind Card.VolumeRowHeight, Mode=OneWay}"
+                <Grid Grid.Column="0" Height="{x:Bind Presentation.Options.VolumeRowHeight, Mode=OneWay}"
                       Grid.ColumnSpan="{x:Bind Card.VolumeMeterColumnSpan, Mode=OneWay}"
                       Opacity="{x:Bind Card.VolumeAreaOpacity, Mode=OneWay}">
 
-                    <Grid Visibility="{x:Bind Card.MeterOptions.ShowMeter, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid Visibility="{x:Bind Presentation.Options.ShowMeter, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <controls:ChannelPeakMeter Margin="{x:Bind Card.MeterMargin, Mode=OneWay}"
                                                    VerticalAlignment="Center"
-                                                   TotalHeightOverride="{x:Bind Card.MeterTotalHeight, Mode=OneWay}"
+                                                   TotalHeightOverride="{x:Bind Presentation.Options.MeterTotalHeight, Mode=OneWay}"
                                                    ChannelCount="{x:Bind Card.ChannelCount, Mode=OneWay}"
-                                                   ColourMode="{x:Bind Card.MeterOptions.ColourMode, Mode=OneWay}"
-                                                   SingleColour="{x:Bind Card.MeterOptions.SingleColour, Mode=OneWay}"
-                                                   ChannelMode="{x:Bind Card.MeterOptions.ChannelMode, Mode=OneWay}"
-                                                   ShowHold="{x:Bind Card.MeterOptions.ShowHold, Mode=OneWay}"
+                                                   ColourMode="{x:Bind Presentation.Options.ColourMode, Mode=OneWay}"
+                                                   SingleColour="{x:Bind Presentation.Options.SingleColour, Mode=OneWay}"
+                                                   ChannelMode="{x:Bind Presentation.Options.ChannelMode, Mode=OneWay}"
+                                                   ShowHold="{x:Bind Presentation.Options.ShowHold, Mode=OneWay}"
                                                    LeftLevel="{x:Bind Card.LeftLevel, Mode=OneWay}"
                                                    RightLevel="{x:Bind Card.RightLevel, Mode=OneWay}"
                                                    CentreLfeLevel="{x:Bind Card.CentreLfeLevel, Mode=OneWay}"
@@ -303,7 +303,7 @@
                                 StepFrequency="1"
                                 SmallChange="1"
                                 LargeChange="5"
-                                Margin="{x:Bind Card.VolumeSliderMargin, Mode=OneWay}"
+                                Margin="{x:Bind Presentation.Options.VolumeSliderMargin, Mode=OneWay}"
                                 Padding="8,0,8,0"
                                 Value="{x:Bind Card.VolumePercent, Mode=TwoWay}"
                                 IsEnabled="{x:Bind Card.IsVolumeEditable, Mode=OneWay}"
@@ -353,7 +353,7 @@
                             KeyUp="OnSliderKeyUp"
                             LostFocus="OnSliderLostFocus"
                             VerticalAlignment="Center"
-                            Visibility="{x:Bind Card.ShowPlainSlider, Mode=OneWay}" />
+                            Visibility="{x:Bind Presentation.ShowPlainSlider, Mode=OneWay}" />
 
                     <Border Background="Transparent"
                             Tapped="OnLockedSliderTapped"
@@ -387,18 +387,18 @@
                  in strip mode the band is a filled block whose own edges separate it (no bracketing
                  hairlines - it also suppresses the divider directly below it; see DeviceCard). Lives on the
                  Devices page and in Quick Controls alike (independent of ShowRules). -->
-            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
+            <Border Height="1" Margin="{x:Bind Presentation.Options.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource DividerStrokeColorDefaultBrush}"
-                    Visibility="{x:Bind Card.ShowNowPlayingDivider, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    Visibility="{x:Bind Presentation.ShowNowPlayingDivider, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
             <!-- Bleed to the card edges (-16) but keep the natural section spacing top/bottom: with no
                  bracketing hairlines (strip mode) the band would otherwise butt straight against the rows
                  above/below. Zero vertical margin lets the StackPanel's 12px spacing sit it apart like every
                  other section (no negative margin, so nothing to round at fractional DPI). -->
-            <ItemsControl ItemsSource="{x:Bind Card.NowPlayingStrips, Mode=OneWay}"
+            <ItemsControl ItemsSource="{x:Bind Presentation.NowPlayingStrips, Mode=OneWay}"
                           HorizontalAlignment="Stretch"
                           HorizontalContentAlignment="Stretch"
-                          Margin="{x:Bind Card.EdgeBleedMargin, Mode=OneWay}"
-                          Visibility="{x:Bind Card.ShowNowPlaying, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                          Margin="{x:Bind Presentation.Options.EdgeBleedMargin, Mode=OneWay}"
+                          Visibility="{x:Bind Presentation.ShowNowPlaying, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <StackPanel Spacing="4" />
@@ -411,34 +411,34 @@
                     </Style>
                 </ItemsControl.ItemContainerStyle>
                 <ItemsControl.ItemTemplate>
-                    <DataTemplate x:DataType="vm:NowPlayingStrip">
+                    <DataTemplate x:DataType="vm:NowPlayingStripView">
                             <Border>
                                 <Grid>
                                     <!-- The strip's own artwork band. Hidden when "fill card background"
                                          is on, because the whole card already shows the artwork + a single
                                          scrim; painting it again here would double up and look inconsistent. -->
-                                    <Grid Visibility="{x:Bind MeterOptions.NowPlayingCardBackground, Mode=OneWay, Converter={StaticResource NegatedBooleanToVisibilityConverter}}">
+                                    <Grid Visibility="{x:Bind Options.NowPlayingCardBackground, Mode=OneWay, Converter={StaticResource NegatedBooleanToVisibilityConverter}}">
                                         <!-- Artwork backdrop. CrossfadeImage reports zero desired size
                                              (like a Brush) so it cover-fills the content height instead of
                                              inflating it, and eases between artworks on a track change. -->
-                                        <controls:CrossfadeImage Source="{x:Bind BackdropSource, Mode=OneWay}"
+                                        <controls:CrossfadeImage Source="{x:Bind Strip.BackdropSource, Mode=OneWay}"
                                                                  Stretch="UniformToFill" />
                                         <!-- Frost: in-app acrylic over low-res art only (high-res fills
                                              sharp); the compositor blurs the fill, no Win2D. -->
                                         <Border Background="{ThemeResource NowPlayingFrostBrush}"
-                                                Visibility="{x:Bind BackdropFrosted, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                Visibility="{x:Bind Strip.BackdropFrosted, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                         <!-- Scrim for sharp art only: keeps the card's themed text/controls
                                              legible. Frosted art is dimmed by the acrylic above, so the scrim
                                              is dropped there to avoid double-darkening. -->
                                         <Border Background="{ThemeResource NowPlayingScrimBrush}"
-                                                Visibility="{x:Bind BackdropFrosted, Mode=OneWay, Converter={StaticResource NegatedBooleanToVisibilityConverter}}" />
+                                                Visibility="{x:Bind Strip.BackdropFrosted, Mode=OneWay, Converter={StaticResource NegatedBooleanToVisibilityConverter}}" />
                                     </Grid>
 
                                     <!-- Horizontal inset stays 16 so the strip content lines up with the
                                          rest of the card. Top inset is 12 (matches the row spacing); the
                                          bottom is trimmed to 6 because the seek slider already carries its
                                          own height below the track, which otherwise reads as too much gap. -->
-                                    <Grid Padding="{x:Bind MeterOptions.NowPlayingStripPadding, Mode=OneWay}" ColumnSpacing="10">
+                                    <Grid Padding="{x:Bind Options.NowPlayingStripPadding, Mode=OneWay}" ColumnSpacing="10">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
@@ -450,24 +450,28 @@
                                         </Grid.RowDefinitions>
 
                                         <!-- Top-left: app icon + label, with the app's live peak meter
-                                             underneath (same control as the apps-row chips). -->
-                                        <StackPanel Grid.Row="0" Grid.Column="0" Spacing="3" VerticalAlignment="Top">
+                                             underneath (same control as the apps-row chips). Compact hides
+                                             this whole line (the icon is hoisted inline onto the title and
+                                             the label/meter dropped) so the title/artist + controls rise to
+                                             the top. -->
+                                        <StackPanel Grid.Row="0" Grid.Column="0" Spacing="3" VerticalAlignment="Top"
+                                                    Visibility="{x:Bind Options.CompactCards, Mode=OneWay, Converter={StaticResource NegatedBooleanToVisibilityConverter}}">
                                             <StackPanel Orientation="Horizontal" Spacing="6">
                                                 <Grid Width="16" Height="16">
-                                                    <FontIcon Glyph="{x:Bind Chip.FallbackGlyph, Mode=OneWay}"
+                                                    <FontIcon Glyph="{x:Bind Strip.Chip.FallbackGlyph, Mode=OneWay}"
                                                               FontSize="12"
                                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                              Visibility="{x:Bind Chip.HasNoIcon, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                                    <Image Source="{x:Bind Chip.Icon, Mode=OneWay}"
+                                                              Visibility="{x:Bind Strip.Chip.HasNoIcon, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                    <Image Source="{x:Bind Strip.Chip.Icon, Mode=OneWay}"
                                                            Stretch="Uniform"
-                                                           Visibility="{x:Bind Chip.HasIcon, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                           Visibility="{x:Bind Strip.Chip.HasIcon, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                                 </Grid>
-                                                <TextBlock Text="{x:Bind Chip.DisplayLabel, Mode=OneWay}"
+                                                <TextBlock Text="{x:Bind Strip.Chip.DisplayLabel, Mode=OneWay}"
                                                            Style="{StaticResource CaptionTextBlockStyle}"
                                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                                            TextTrimming="CharacterEllipsis"
                                                            TextWrapping="NoWrap"
-                                                           ToolTipService.ToolTip="{x:Bind Chip.DisplayLabel, Mode=OneWay}" />
+                                                           ToolTipService.ToolTip="{x:Bind Strip.Chip.DisplayLabel, Mode=OneWay}" />
                                             </StackPanel>
                                             <controls:ChannelPeakMeter Width="110"
                                                                        HorizontalAlignment="Left"
@@ -475,55 +479,81 @@
                                                                        BarHeightOverride="3"
                                                                        ShowHold="False"
                                                                        Volume="1.0"
-                                                                       Visibility="{x:Bind MeterOptions.ShowAppMeters, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                                       LeftLevel="{x:Bind Chip.PeakLevelScalar, Mode=OneWay}" />
+                                                                       Visibility="{x:Bind Options.ShowAppMeters, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                                       LeftLevel="{x:Bind Strip.Chip.PeakLevelScalar, Mode=OneWay}" />
                                         </StackPanel>
 
-                                        <!-- Title + artist. -->
-                                        <StackPanel Grid.Row="1" Grid.Column="0" VerticalAlignment="Bottom" Margin="0,6,0,0">
-                                            <TextBlock Text="{x:Bind Title, Mode=OneWay}"
-                                                       Style="{StaticResource BodyStrongTextBlockStyle}"
-                                                       TextTrimming="CharacterEllipsis"
-                                                       TextWrapping="NoWrap"
-                                                       ToolTipService.ToolTip="{x:Bind Title, Mode=OneWay}" />
-                                            <TextBlock Text="{x:Bind Artist, Mode=OneWay}"
-                                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                       TextTrimming="CharacterEllipsis"
-                                                       TextWrapping="NoWrap"
-                                                       ToolTipService.ToolTip="{x:Bind Artist, Mode=OneWay}"
-                                                       Visibility="{x:Bind HasArtist, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                        </StackPanel>
+                                        <!-- Title + artist. Compact prefixes the app icon inline (the
+                                             app-name line above is hidden in compact) via a leading Auto
+                                             column that collapses to zero in the roomy layout, so the title
+                                             stays flush-left and trimmed there exactly as before. -->
+                                        <Grid Grid.Row="1" Grid.Column="0"
+                                              VerticalAlignment="{x:Bind Options.NowPlayingTitleVAlign, Mode=OneWay}"
+                                              Margin="{x:Bind Options.NowPlayingTitleMargin, Mode=OneWay}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid Grid.Column="0" Width="16" Height="16"
+                                                  VerticalAlignment="Center" Margin="0,0,6,0"
+                                                  Visibility="{x:Bind Options.CompactCards, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <FontIcon Glyph="{x:Bind Strip.Chip.FallbackGlyph, Mode=OneWay}"
+                                                          FontSize="12"
+                                                          Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                          Visibility="{x:Bind Strip.Chip.HasNoIcon, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                <Image Source="{x:Bind Strip.Chip.Icon, Mode=OneWay}"
+                                                       Stretch="Uniform"
+                                                       Visibility="{x:Bind Strip.Chip.HasIcon, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                            </Grid>
+                                            <StackPanel Grid.Column="1">
+                                                <TextBlock Text="{x:Bind Strip.Title, Mode=OneWay}"
+                                                           Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           TextWrapping="NoWrap"
+                                                           ToolTipService.ToolTip="{x:Bind Strip.Title, Mode=OneWay}" />
+                                                <TextBlock Text="{x:Bind Strip.Artist, Mode=OneWay}"
+                                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           TextWrapping="NoWrap"
+                                                           ToolTipService.ToolTip="{x:Bind Strip.Artist, Mode=OneWay}"
+                                                           Visibility="{x:Bind Strip.HasArtist, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                            </StackPanel>
+                                        </Grid>
 
-                                        <!-- Transport controls, centred against the title block. -->
-                                        <StackPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                        <!-- Transport controls, centred against the title block. Compact
+                                             drops into the title row only (the app-name row above is hidden)
+                                             so they centre with the title+artist instead of the empty row. -->
+                                        <StackPanel Grid.Row="{x:Bind Options.NowPlayingControlsRow, Mode=OneWay}"
+                                                    Grid.RowSpan="{x:Bind Options.NowPlayingControlsRowSpan, Mode=OneWay}"
+                                                    Grid.Column="1"
                                                     Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
                                             <Button Style="{StaticResource GhostIconButtonStyle}"
-                                                    Width="32" Height="32" Padding="0" MinWidth="0"
-                                                    CornerRadius="16"
-                                                    Command="{x:Bind PreviousCommand}"
-                                                    IsEnabled="{x:Bind CanPrevious, Mode=OneWay}"
+                                                    Width="{x:Bind Options.NowPlayingSkipSize, Mode=OneWay}" Height="{x:Bind Options.NowPlayingSkipSize, Mode=OneWay}" Padding="0" MinWidth="0"
+                                                    CornerRadius="{x:Bind Options.NowPlayingSkipCorner, Mode=OneWay}"
+                                                    Command="{x:Bind Strip.PreviousCommand}"
+                                                    IsEnabled="{x:Bind Strip.CanPrevious, Mode=OneWay}"
                                                     ToolTipService.ToolTip="Previous"
                                                     AutomationProperties.Name="Previous track">
-                                                <FontIcon Glyph="&#xE892;" FontSize="14" />
+                                                <FontIcon Glyph="&#xE892;" FontSize="{x:Bind Options.NowPlayingSkipGlyph, Mode=OneWay}" />
                                             </Button>
                                             <Button Style="{StaticResource AccentButtonStyle}"
-                                                    Width="36" Height="36" Padding="0" MinWidth="0"
-                                                    CornerRadius="18"
-                                                    Command="{x:Bind PlayPauseCommand}"
-                                                    IsEnabled="{x:Bind CanPlayPause, Mode=OneWay}"
-                                                    ToolTipService.ToolTip="{x:Bind PlayPauseTooltip, Mode=OneWay}"
-                                                    AutomationProperties.Name="{x:Bind PlayPauseTooltip, Mode=OneWay}">
-                                                <FontIcon Glyph="{x:Bind PlayPauseGlyph, Mode=OneWay}" FontSize="16" />
+                                                    Width="{x:Bind Options.NowPlayingPlaySize, Mode=OneWay}" Height="{x:Bind Options.NowPlayingPlaySize, Mode=OneWay}" Padding="0" MinWidth="0"
+                                                    CornerRadius="{x:Bind Options.NowPlayingPlayCorner, Mode=OneWay}"
+                                                    Command="{x:Bind Strip.PlayPauseCommand}"
+                                                    IsEnabled="{x:Bind Strip.CanPlayPause, Mode=OneWay}"
+                                                    ToolTipService.ToolTip="{x:Bind Strip.PlayPauseTooltip, Mode=OneWay}"
+                                                    AutomationProperties.Name="{x:Bind Strip.PlayPauseTooltip, Mode=OneWay}">
+                                                <FontIcon Glyph="{x:Bind Strip.PlayPauseGlyph, Mode=OneWay}" FontSize="{x:Bind Options.NowPlayingPlayGlyph, Mode=OneWay}" />
                                             </Button>
                                             <Button Style="{StaticResource GhostIconButtonStyle}"
-                                                    Width="32" Height="32" Padding="0" MinWidth="0"
-                                                    CornerRadius="16"
-                                                    Command="{x:Bind NextCommand}"
-                                                    IsEnabled="{x:Bind CanNext, Mode=OneWay}"
+                                                    Width="{x:Bind Options.NowPlayingSkipSize, Mode=OneWay}" Height="{x:Bind Options.NowPlayingSkipSize, Mode=OneWay}" Padding="0" MinWidth="0"
+                                                    CornerRadius="{x:Bind Options.NowPlayingSkipCorner, Mode=OneWay}"
+                                                    Command="{x:Bind Strip.NextCommand}"
+                                                    IsEnabled="{x:Bind Strip.CanNext, Mode=OneWay}"
                                                     ToolTipService.ToolTip="Next"
                                                     AutomationProperties.Name="Next track">
-                                                <FontIcon Glyph="&#xE893;" FontSize="14" />
+                                                <FontIcon Glyph="&#xE893;" FontSize="{x:Bind Options.NowPlayingSkipGlyph, Mode=OneWay}" />
                                             </Button>
                                         </StackPanel>
 
@@ -532,31 +562,38 @@
                                              shows a timestamp; a drag seeks on release (Esc cancels).
                                              Pointer handlers are wired in code-behind with handledEventsToo
                                              so grabbing the thumb still freezes the bar. -->
-                                        <Slider Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
-                                                Minimum="0"
-                                                Maximum="{x:Bind DurationSeconds, Mode=OneWay}"
-                                                StepFrequency="1"
-                                                Value="{x:Bind PositionSeconds, Mode=OneWay}"
-                                                ThumbToolTipValueConverter="{StaticResource SecondsToTimestampConverter}"
-                                                Margin="0,2,0,-4"
-                                                VerticalAlignment="Bottom"
-                                                Tag="{x:Bind}"
-                                                Loaded="OnSeekSliderLoaded"
-                                                Visibility="{x:Bind HasProgress, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                            <!-- Default (theme-aware, accessible) slider chrome; thumb
-                                                 sized to match the volume slider for visual consistency. -->
-                                            <Slider.Resources>
-                                                <x:Double x:Key="SliderHorizontalThumbWidth">14</x:Double>
-                                                <x:Double x:Key="SliderHorizontalThumbHeight">14</x:Double>
-                                            </Slider.Resources>
-                                        </Slider>
+                                        <!-- Seek host: a fixed-height row in compact (16) that the slider
+                                             overflows centred (the host doesn't clip), so the row is slim
+                                             without the template's 32px body padding out the bottom and
+                                             without clipping the thumb. Auto height in the roomy layout. -->
+                                        <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                                              Height="{x:Bind Options.NowPlayingSeekHostHeight, Mode=OneWay}"
+                                              Margin="{x:Bind Options.NowPlayingSeekHostMargin, Mode=OneWay}"
+                                              Visibility="{x:Bind Strip.HasProgress, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            <Slider Minimum="0"
+                                                    Maximum="{x:Bind Strip.DurationSeconds, Mode=OneWay}"
+                                                    StepFrequency="1"
+                                                    Value="{x:Bind Strip.PositionSeconds, Mode=OneWay}"
+                                                    ThumbToolTipValueConverter="{StaticResource SecondsToTimestampConverter}"
+                                                    Margin="{x:Bind Options.NowPlayingSeekMargin, Mode=OneWay}"
+                                                    VerticalAlignment="{x:Bind Options.NowPlayingSeekVAlign, Mode=OneWay}"
+                                                    Tag="{x:Bind Strip}"
+                                                    Loaded="OnSeekSliderLoaded">
+                                                <!-- Default (theme-aware, accessible) slider chrome; thumb
+                                                     sized to match the volume slider for visual consistency. -->
+                                                <Slider.Resources>
+                                                    <x:Double x:Key="SliderHorizontalThumbWidth">14</x:Double>
+                                                    <x:Double x:Key="SliderHorizontalThumbHeight">14</x:Double>
+                                                </Slider.Resources>
+                                            </Slider>
+                                        </Grid>
 
                                         <!-- LIVE indicator: shown instead of the seek bar for a live /
                                              non-seekable stream (no usable timeline). -->
                                         <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                                                     Orientation="Horizontal" Spacing="6"
                                                     VerticalAlignment="Bottom" Margin="0,6,0,0"
-                                                    Visibility="{x:Bind IsLive, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    Visibility="{x:Bind Strip.IsLive, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                             <Ellipse Width="8" Height="8"
                                                      Fill="{ThemeResource SystemFillColorCriticalBrush}"
                                                      VerticalAlignment="Center" />
@@ -574,16 +611,16 @@
             </ItemsControl>
 
             <!-- Apps row carries the hairline above itself (section dividers on + a row present). -->
-            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
+            <Border Height="1" Margin="{x:Bind Presentation.Options.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource DividerStrokeColorDefaultBrush}"
-                    Visibility="{x:Bind DividerOverArt(Card.ShowAppsDivider, Card.ShowCardBackground), Mode=OneWay}" />
-            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
+                    Visibility="{x:Bind DividerOverArt(Presentation.ShowAppsDivider, Presentation.ShowCardBackground), Mode=OneWay}" />
+            <Border Height="1" Margin="{x:Bind Presentation.Options.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
-                    Visibility="{x:Bind DividerPlain(Card.ShowAppsDivider, Card.ShowCardBackground), Mode=OneWay}" />
+                    Visibility="{x:Bind DividerPlain(Presentation.ShowAppsDivider, Presentation.ShowCardBackground), Mode=OneWay}" />
 
             <!-- Apps row. Each chip is the app's icon with a peak underbar; drag a chip onto another
                  render card to move the app's output there (the drop is handled by the host Border). -->
-            <StackPanel Spacing="{StaticResource SpacingXSmall}" Visibility="{x:Bind Card.ShowAppsSection, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <StackPanel Spacing="{StaticResource SpacingXSmall}" Visibility="{x:Bind Presentation.ShowAppsSection, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <ItemsControl ItemsSource="{x:Bind Card.Apps}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
@@ -690,20 +727,20 @@
 
             <!-- Rules block carries the hairline above itself (host ShowRules + section dividers on
                  + the block has content - a rules list or the "no rules" message). -->
-            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
+            <Border Height="1" Margin="{x:Bind Presentation.Options.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource DividerStrokeColorDefaultBrush}"
-                    Visibility="{x:Bind RuleDividerOverArt(ShowRules, Card.ShowRulesDivider, Card.ShowCardBackground), Mode=OneWay}" />
-            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
+                    Visibility="{x:Bind DividerOverArt(Presentation.ShowRulesDivider, Presentation.ShowCardBackground), Mode=OneWay}" />
+            <Border Height="1" Margin="{x:Bind Presentation.Options.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
-                    Visibility="{x:Bind RuleDividerPlain(ShowRules, Card.ShowRulesDivider, Card.ShowCardBackground), Mode=OneWay}" />
+                    Visibility="{x:Bind DividerPlain(Presentation.ShowRulesDivider, Presentation.ShowCardBackground), Mode=OneWay}" />
 
             <!-- Rules section. First rule chip always visible; the chevron toggles the rest. -->
             <StackPanel Spacing="{StaticResource SpacingXSmall}"
-                        Visibility="{x:Bind RuleVis(ShowRules, Card.ShowRulesSection), Mode=OneWay}">
+                        Visibility="{x:Bind Presentation.ShowRulesSection, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock Text="Rules"
                            Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                           Visibility="{x:Bind Card.ShowRulesCaption, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                           Visibility="{x:Bind Presentation.Options.ShowRulesCaption, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                 <controls:ExpanderPill Margin="0,2,0,0"
                                        IsExpanded="{x:Bind Card.IsRulesExpanded, Mode=TwoWay}"
@@ -713,12 +750,12 @@
                     <controls:ExpanderPill.PillContent>
                         <Button Style="{StaticResource SubtleRuleChipButtonStyle}"
                                 Background="Transparent"
-                                Padding="{x:Bind Card.RuleChipPadding, Mode=OneWay}"
+                                Padding="{x:Bind Presentation.Options.RuleChipPadding, Mode=OneWay}"
                                 Opacity="{x:Bind Card.FirstRule.Opacity, FallbackValue=1.0, Mode=OneWay}"
                                 DataContext="{x:Bind Card.FirstRule, Mode=OneWay}"
                                 Click="OnRuleChipClicked"
                                 ToolTipService.ToolTip="Open in Rules">
-                            <StackPanel Spacing="{x:Bind Card.RuleChipSpacing, Mode=OneWay}">
+                            <StackPanel Spacing="{x:Bind Presentation.Options.RuleChipSpacing, Mode=OneWay}">
                                 <TextBlock Text="{x:Bind Card.FirstRule.Name, Mode=OneWay, FallbackValue=''}"
                                            Style="{StaticResource BodyStrongTextBlockStyle}"
                                            TextTrimming="CharacterEllipsis"
@@ -772,7 +809,7 @@
 
             <TextBlock Text="No rules target this device."
                        Style="{StaticResource MutedCaptionTextStyle}"
-                       Visibility="{x:Bind RuleVis(ShowRules, Card.ShowNoRulesMessage), Mode=OneWay}" />
+                       Visibility="{x:Bind Presentation.ShowNoRulesMessage, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
         </StackPanel>
 
         <!-- Transient accent dotted outline shown while a drag hovers this card's centre to group. -->

--- a/src/Earmark.App/Controls/DeviceCardView.xaml
+++ b/src/Earmark.App/Controls/DeviceCardView.xaml
@@ -12,10 +12,11 @@
         <DataTemplate x:Key="RuleChipTemplate" x:DataType="vm:RuleSummary">
             <Button Style="{StaticResource SubtleRuleChipButtonStyle}"
                     Margin="0,2,0,0"
+                    Padding="{x:Bind Options.RuleChipPadding, Mode=OneWay}"
                     Opacity="{x:Bind Opacity}"
                     Click="OnRuleChipClicked"
                     ToolTipService.ToolTip="Open in Rules">
-                <StackPanel Spacing="{StaticResource SpacingXXSmall}">
+                <StackPanel Spacing="{x:Bind Options.RuleChipSpacing, Mode=OneWay}">
                     <TextBlock Text="{x:Bind Name}"
                                Style="{StaticResource BodyStrongTextBlockStyle}"
                                TextTrimming="CharacterEllipsis"
@@ -75,8 +76,10 @@
         <Border Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}"
                 CornerRadius="{StaticResource CardCornerRadius}"
                 Visibility="{x:Bind Card.IsMuted, Mode=OneWay}" />
-        <StackPanel Spacing="{StaticResource SpacingMedium}" Margin="{StaticResource SectionPadding}">
-            <!-- Header: mute toggle (icon) + name + chips + (Bluetooth) connect/disconnect -->
+        <StackPanel x:Name="SectionStack" Spacing="{x:Bind Card.CardSectionSpacing, Mode=OneWay}" Margin="{x:Bind Card.CardContentPadding, Mode=OneWay}">
+            <!-- Header: mute toggle (icon) + name + chips + (Bluetooth) connect/disconnect. Wrapped so
+                 compact can hoist the pills to a full-width row below the icon/name (see end of stack). -->
+            <StackPanel Spacing="4">
             <Grid ColumnSpacing="{StaticResource SpacingSmall}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -87,14 +90,14 @@
                 <Border Grid.Column="0"
                         Background="Transparent"
                         ToolTipService.ToolTip="{x:Bind Card.MuteTooltip, Mode=OneWay}">
-                    <Grid Width="56" Height="56">
+                    <Grid Width="{x:Bind Card.IconTileSize, Mode=OneWay}" Height="{x:Bind Card.IconTileSize, Mode=OneWay}">
                         <Border CornerRadius="{StaticResource CardCornerRadius}"
                                 Background="{ThemeResource SubtleFillColorSecondaryBrush}"
                                 Visibility="{x:Bind Card.ShowDefaultTile, Mode=OneWay}" />
                         <Border CornerRadius="{StaticResource CardCornerRadius}"
                                 Background="{x:Bind Card.WaveLinkTileBrush, Mode=OneWay}"
                                 Visibility="{x:Bind Card.ShowAccentTile, Mode=OneWay}" />
-                        <Button Width="56" Height="56"
+                        <Button Width="{x:Bind Card.IconTileSize, Mode=OneWay}" Height="{x:Bind Card.IconTileSize, Mode=OneWay}"
                                 Padding="0"
                                 Background="Transparent"
                                 BorderBrush="Transparent"
@@ -114,19 +117,19 @@
                             </Button.Resources>
                             <Grid>
                                 <FontIcon Glyph="{x:Bind Card.Glyph, Mode=OneWay}"
-                                          FontSize="28"
+                                          FontSize="{x:Bind Card.IconGlyphSize, Mode=OneWay}"
                                           Visibility="{x:Bind Card.GlyphOnAccent, Mode=OneWay}"
                                           Foreground="{x:Bind Card.GlyphContrastBrush, Mode=OneWay}" />
                                 <FontIcon Glyph="{x:Bind Card.Glyph, Mode=OneWay}"
-                                          FontSize="28"
+                                          FontSize="{x:Bind Card.IconGlyphSize, Mode=OneWay}"
                                           Visibility="{x:Bind Card.GlyphNormalThemed, Mode=OneWay}"
                                           Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                                 <FontIcon Glyph="{x:Bind Card.Glyph, Mode=OneWay}"
-                                          FontSize="28"
+                                          FontSize="{x:Bind Card.IconGlyphSize, Mode=OneWay}"
                                           Visibility="{x:Bind Card.GlyphMutedThemed, Mode=OneWay}"
                                           Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
                                 <Image Source="{x:Bind Card.WaveLinkIconSource, Mode=OneWay}"
-                                       Width="40" Height="40"
+                                       Width="{x:Bind Card.WaveLinkIconSize, Mode=OneWay}" Height="{x:Bind Card.WaveLinkIconSize, Mode=OneWay}"
                                        Visibility="{x:Bind Card.ShowWaveLinkIcon, Mode=OneWay}" />
                             </Grid>
                         </Button>
@@ -176,9 +179,13 @@
                                TextWrapping="NoWrap"
                                TextTrimming="CharacterEllipsis"
                                Visibility="{x:Bind Card.HasDeviceIdSubtext, Mode=OneWay}" />
+                    <!-- Pills inline under the name (normal layout). In compact they're hoisted to a
+                         full-width row below the header so the icon tile sizes to the name+id height
+                         instead of centring against a three-line block; kept in sync with that copy. -->
                     <StackPanel Orientation="Horizontal"
                                 Spacing="6"
-                                Margin="-8,4,0,0">
+                                Margin="-8,4,0,0"
+                                Visibility="{x:Bind Card.ShowNormalBadges, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <Border Padding="8,2"
                                 VerticalAlignment="Center"
                                 Visibility="{x:Bind Card.ShowFlowLabel, Mode=OneWay}">
@@ -226,6 +233,40 @@
                 </StackPanel>
             </Grid>
 
+            <!-- Compact-only pills row: hoisted out from under the name to a full-width row whose left
+                 edge sits flush with the icon tile (content padding). The flow label drops its left
+                 inset so its text lines up with the icon too. Mirrors the inline pills above - keep in
+                 sync. -->
+            <StackPanel Orientation="Horizontal"
+                        Spacing="6"
+                        Visibility="{x:Bind Card.ShowCompactBadges, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Border Padding="0,2,8,2"
+                        VerticalAlignment="Center"
+                        Visibility="{x:Bind Card.ShowFlowLabel, Mode=OneWay}">
+                    <TextBlock Text="{x:Bind Card.FlowLabel, Mode=OneWay}"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                </Border>
+                <Border Style="{StaticResource ChipBorderStyle}"
+                        Visibility="{x:Bind Card.IsDefault, Mode=OneWay}">
+                    <TextBlock Text="{x:Bind Card.DefaultPillText, Mode=OneWay}"
+                               Style="{StaticResource CaptionTextBlockStyle}" />
+                </Border>
+                <Border Style="{StaticResource ChipBorderStyle}"
+                        Visibility="{x:Bind Card.IsDefaultCommunications, Mode=OneWay}">
+                    <TextBlock Text="{x:Bind Card.CommunicationsPillText, Mode=OneWay}"
+                               Style="{StaticResource CaptionTextBlockStyle}" />
+                </Border>
+                <Border Style="{StaticResource ChipBorderStyle}"
+                        Visibility="{x:Bind Card.ShowDisconnectedBadge, Mode=OneWay}"
+                        ToolTipService.ToolTip="This device isn't connected right now. Its settings are remembered and it reactivates when it reconnects.">
+                    <TextBlock Text="Disconnected"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                </Border>
+            </StackPanel>
+            </StackPanel>
+
             <!-- Volume row: peak meter behind a transparent-track slider, or a plain slider when the
                  meter is Off. Collapses entirely only when both slider and meter are hidden. -->
             <Grid ColumnSpacing="{StaticResource SpacingSmall}"
@@ -236,13 +277,14 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <Grid Grid.Column="0" Height="28"
+                <Grid Grid.Column="0" Height="{x:Bind Card.VolumeRowHeight, Mode=OneWay}"
                       Grid.ColumnSpan="{x:Bind Card.VolumeMeterColumnSpan, Mode=OneWay}"
                       Opacity="{x:Bind Card.VolumeAreaOpacity, Mode=OneWay}">
 
                     <Grid Visibility="{x:Bind Card.MeterOptions.ShowMeter, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <controls:ChannelPeakMeter Margin="{x:Bind Card.MeterMargin, Mode=OneWay}"
                                                    VerticalAlignment="Center"
+                                                   TotalHeightOverride="{x:Bind Card.MeterTotalHeight, Mode=OneWay}"
                                                    ChannelCount="{x:Bind Card.ChannelCount, Mode=OneWay}"
                                                    ColourMode="{x:Bind Card.MeterOptions.ColourMode, Mode=OneWay}"
                                                    SingleColour="{x:Bind Card.MeterOptions.SingleColour, Mode=OneWay}"
@@ -261,7 +303,7 @@
                                 StepFrequency="1"
                                 SmallChange="1"
                                 LargeChange="5"
-                                Margin="0,0,2,0"
+                                Margin="{x:Bind Card.VolumeSliderMargin, Mode=OneWay}"
                                 Padding="8,0,8,0"
                                 Value="{x:Bind Card.VolumePercent, Mode=TwoWay}"
                                 IsEnabled="{x:Bind Card.IsVolumeEditable, Mode=OneWay}"
@@ -345,7 +387,7 @@
                  in strip mode the band is a filled block whose own edges separate it (no bracketing
                  hairlines - it also suppresses the divider directly below it; see DeviceCard). Lives on the
                  Devices page and in Quick Controls alike (independent of ShowRules). -->
-            <Border Height="1" Margin="-16,0,-16,-6"
+            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource DividerStrokeColorDefaultBrush}"
                     Visibility="{x:Bind Card.ShowNowPlayingDivider, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
             <!-- Bleed to the card edges (-16) but keep the natural section spacing top/bottom: with no
@@ -355,7 +397,7 @@
             <ItemsControl ItemsSource="{x:Bind Card.NowPlayingStrips, Mode=OneWay}"
                           HorizontalAlignment="Stretch"
                           HorizontalContentAlignment="Stretch"
-                          Margin="-16,0,-16,0"
+                          Margin="{x:Bind Card.EdgeBleedMargin, Mode=OneWay}"
                           Visibility="{x:Bind Card.ShowNowPlaying, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
@@ -396,7 +438,7 @@
                                          rest of the card. Top inset is 12 (matches the row spacing); the
                                          bottom is trimmed to 6 because the seek slider already carries its
                                          own height below the track, which otherwise reads as too much gap. -->
-                                    <Grid Padding="16,12,16,6" ColumnSpacing="10">
+                                    <Grid Padding="{x:Bind MeterOptions.NowPlayingStripPadding, Mode=OneWay}" ColumnSpacing="10">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="Auto" />
@@ -532,10 +574,10 @@
             </ItemsControl>
 
             <!-- Apps row carries the hairline above itself (section dividers on + a row present). -->
-            <Border Height="1" Margin="-16,0,-16,-6"
+            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource DividerStrokeColorDefaultBrush}"
                     Visibility="{x:Bind DividerOverArt(Card.ShowAppsDivider, Card.ShowCardBackground), Mode=OneWay}" />
-            <Border Height="1" Margin="-16,0,-16,-6"
+            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
                     Visibility="{x:Bind DividerPlain(Card.ShowAppsDivider, Card.ShowCardBackground), Mode=OneWay}" />
 
@@ -648,10 +690,10 @@
 
             <!-- Rules block carries the hairline above itself (host ShowRules + section dividers on
                  + the block has content - a rules list or the "no rules" message). -->
-            <Border Height="1" Margin="-16,0,-16,-6"
+            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource DividerStrokeColorDefaultBrush}"
                     Visibility="{x:Bind RuleDividerOverArt(ShowRules, Card.ShowRulesDivider, Card.ShowCardBackground), Mode=OneWay}" />
-            <Border Height="1" Margin="-16,0,-16,-6"
+            <Border Height="1" Margin="{x:Bind Card.SectionDividerMargin, Mode=OneWay}"
                     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
                     Visibility="{x:Bind RuleDividerPlain(ShowRules, Card.ShowRulesDivider, Card.ShowCardBackground), Mode=OneWay}" />
 
@@ -660,7 +702,8 @@
                         Visibility="{x:Bind RuleVis(ShowRules, Card.ShowRulesSection), Mode=OneWay}">
                 <TextBlock Text="Rules"
                            Style="{StaticResource CaptionTextBlockStyle}"
-                           Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           Visibility="{x:Bind Card.ShowRulesCaption, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                 <controls:ExpanderPill Margin="0,2,0,0"
                                        IsExpanded="{x:Bind Card.IsRulesExpanded, Mode=TwoWay}"
@@ -670,11 +713,12 @@
                     <controls:ExpanderPill.PillContent>
                         <Button Style="{StaticResource SubtleRuleChipButtonStyle}"
                                 Background="Transparent"
+                                Padding="{x:Bind Card.RuleChipPadding, Mode=OneWay}"
                                 Opacity="{x:Bind Card.FirstRule.Opacity, FallbackValue=1.0, Mode=OneWay}"
                                 DataContext="{x:Bind Card.FirstRule, Mode=OneWay}"
                                 Click="OnRuleChipClicked"
                                 ToolTipService.ToolTip="Open in Rules">
-                            <StackPanel Spacing="{StaticResource SpacingXXSmall}">
+                            <StackPanel Spacing="{x:Bind Card.RuleChipSpacing, Mode=OneWay}">
                                 <TextBlock Text="{x:Bind Card.FirstRule.Name, Mode=OneWay, FallbackValue=''}"
                                            Style="{StaticResource BodyStrongTextBlockStyle}"
                                            TextTrimming="CharacterEllipsis"
@@ -700,10 +744,14 @@
                 <!-- Reveal is animated in code-behind (SetRulesPanelState): MaxHeight drives the real
                      reflow so siblings glide, opacity fades the content, an InsetClip hides the overflow
                      while it grows. Starts Collapsed; code-behind owns Visibility from the first card bind. -->
+                <!-- -4 top cancels the section StackPanel's 4px spacing for this pair, so the gap from the
+                     first-rule chip to the first dropped-down chip equals the gap between the dropped-down
+                     chips themselves (each chip carries its own 2px top margin). -->
                 <ItemsControl x:Name="AdditionalRulesPanel"
                               ItemsSource="{x:Bind Card.AdditionalRules}"
                               HorizontalAlignment="Stretch"
                               HorizontalContentAlignment="Stretch"
+                              Margin="0,-4,0,0"
                               Visibility="Collapsed">
                     <ItemsControl.ItemContainerStyle>
                         <Style TargetType="ContentPresenter">

--- a/src/Earmark.App/Controls/DeviceCardView.xaml.cs
+++ b/src/Earmark.App/Controls/DeviceCardView.xaml.cs
@@ -83,9 +83,21 @@ public sealed partial class DeviceCardView : UserControl
 
     private void OnCardPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(DeviceCard.IsRulesExpanded))
+        switch (e.PropertyName)
         {
-            SetRulesPanelState(sender as DeviceCard, animate: true);
+            case nameof(DeviceCard.IsRulesExpanded):
+                SetRulesPanelState(sender as DeviceCard, animate: true);
+                break;
+
+            // StackPanel.Spacing isn't recalculated when a child's Visibility toggles (a WinUI quirk):
+            // a divider hairline re-renders but the panel keeps the no-divider gap count, so the dividers
+            // come back cramped until something else forces a re-measure (a density change, a new chip).
+            // Force the section stack to re-measure so their spacing returns immediately on the toggle.
+            case nameof(DeviceCard.ShowNowPlayingDivider):
+            case nameof(DeviceCard.ShowAppsDivider):
+            case nameof(DeviceCard.ShowRulesDivider):
+                SectionStack.InvalidateMeasure();
+                break;
         }
     }
 

--- a/src/Earmark.App/Controls/DeviceCardView.xaml.cs
+++ b/src/Earmark.App/Controls/DeviceCardView.xaml.cs
@@ -63,6 +63,41 @@ public sealed partial class DeviceCardView : UserControl
         set => SetValue(CardProperty, value);
     }
 
+    /// <summary>The display options this view renders the card with. Unset (the main window) falls back to
+    /// the card's own (global) options; Quick Controls sets its own so the overlay's rules / now-playing /
+    /// badges / dividers / compact differ from the Devices page. Drives <see cref="Presentation"/>.</summary>
+    public static readonly DependencyProperty OptionsProperty = DependencyProperty.Register(
+        nameof(Options), typeof(PeakMeterOptions), typeof(DeviceCardView), new PropertyMetadata(null, OnOptionsChanged));
+
+    public PeakMeterOptions? Options
+    {
+        get => (PeakMeterOptions?)GetValue(OptionsProperty);
+        set => SetValue(OptionsProperty, value);
+    }
+
+    /// <summary>Per-view presentation (card + this view's options) the XAML binds for display geometry and
+    /// the combine-with-data visibility flags. Rebuilt whenever <see cref="Card"/> or <see cref="Options"/>
+    /// changes.</summary>
+    public static readonly DependencyProperty PresentationProperty = DependencyProperty.Register(
+        nameof(Presentation), typeof(CardPresentation), typeof(DeviceCardView), new PropertyMetadata(null));
+
+    public CardPresentation? Presentation
+    {
+        get => (CardPresentation?)GetValue(PresentationProperty);
+        private set => SetValue(PresentationProperty, value);
+    }
+
+    private static void OnOptionsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is DeviceCardView view) view.RebuildPresentation();
+    }
+
+    private void RebuildPresentation()
+    {
+        (Presentation as IDisposable)?.Dispose();
+        Presentation = Card is { } card ? new CardPresentation(card, Options ?? card.MeterOptions) : null;
+    }
+
     // ---- Rules expand/collapse animation ----
 
     private Storyboard? _rulesStoryboard;
@@ -77,6 +112,7 @@ public sealed partial class DeviceCardView : UserControl
             oldCard.IsRulesCollapsing = false;   // don't leave a recycled card stuck opted-out mid-collapse
         }
         if (e.NewValue is DeviceCard newCard) newCard.PropertyChanged += view.OnCardPropertyChanged;
+        view.RebuildPresentation();
         // Recycle / first bind: snap the rules panel to the new card's resting state, no animation.
         view.SetRulesPanelState(e.NewValue as DeviceCard, animate: false);
     }
@@ -197,17 +233,6 @@ public sealed partial class DeviceCardView : UserControl
         sb.Begin();
     }
 
-    /// <summary>When false (the Quick Controls flyout), the rules divider / section / "no rules"
-    /// message never render. Constant per host.</summary>
-    public static readonly DependencyProperty ShowRulesProperty = DependencyProperty.Register(
-        nameof(ShowRules), typeof(bool), typeof(DeviceCardView), new PropertyMetadata(true));
-
-    public bool ShowRules
-    {
-        get => (bool)GetValue(ShowRulesProperty);
-        set => SetValue(ShowRulesProperty, value);
-    }
-
     /// <summary>When false (the Quick Controls flyout), the card and app-chip right-click menus are
     /// suppressed. Customisation belongs in the main app, not the overlay. Constant per host.</summary>
     public static readonly DependencyProperty AllowContextMenuProperty = DependencyProperty.Register(
@@ -219,10 +244,17 @@ public sealed partial class DeviceCardView : UserControl
         set => SetValue(AllowContextMenuProperty, value);
     }
 
-    /// <summary>x:Bind function: a rule element shows only when rules are enabled for this host AND the
-    /// card wants it. Re-evaluates when either argument changes, replacing the old collapse watchdog.</summary>
-    public Visibility RuleVis(bool showRules, bool cardWants) =>
-        showRules && cardWants ? Visibility.Visible : Visibility.Collapsed;
+    /// <summary>When true (the Quick Controls flyout, where <see cref="AllowContextMenu"/> is false),
+    /// right-clicking a card or app chip shows a single "Settings" item that restores the main window on
+    /// the Quick Controls settings, instead of the full device menu. Constant per host.</summary>
+    public static readonly DependencyProperty QuickControlsMenuProperty = DependencyProperty.Register(
+        nameof(QuickControlsMenu), typeof(bool), typeof(DeviceCardView), new PropertyMetadata(false));
+
+    public bool QuickControlsMenu
+    {
+        get => (bool)GetValue(QuickControlsMenuProperty);
+        set => SetValue(QuickControlsMenuProperty, value);
+    }
 
     // Section dividers split into an over-art variant (a subtle stroke, shown when the card paints its
     // artwork background) and a plain variant (the window base fill, otherwise). Two elements rather
@@ -234,12 +266,6 @@ public sealed partial class DeviceCardView : UserControl
 
     public Visibility DividerPlain(bool wantsDivider, bool overArt) =>
         wantsDivider && !overArt ? Visibility.Visible : Visibility.Collapsed;
-
-    public Visibility RuleDividerOverArt(bool showRules, bool cardWants, bool overArt) =>
-        showRules && cardWants && overArt ? Visibility.Visible : Visibility.Collapsed;
-
-    public Visibility RuleDividerPlain(bool showRules, bool cardWants, bool overArt) =>
-        showRules && cardWants && !overArt ? Visibility.Visible : Visibility.Collapsed;
 
     /// <summary>Raised when "Rename group" is picked from a card/app-chip menu, so the host can focus
     /// the group's title editor (which lives in the page's tree, not here).</summary>
@@ -384,7 +410,13 @@ public sealed partial class DeviceCardView : UserControl
     private void OnAppChipFlyoutOpening(object sender, object e)
     {
         if (sender is not MenuFlyout flyout) return;
-        if (!AllowContextMenu) { flyout.Hide(); return; }
+        if (!AllowContextMenu)
+        {
+            if (!QuickControlsMenu) { flyout.Hide(); return; }
+            flyout.Items.Clear();
+            flyout.Items.Add(BuildQuickControlsSettingsItem());
+            return;
+        }
         if ((flyout.Target as FrameworkElement)?.Tag is not AppChip chip) return;
         flyout.Items.Clear();
 
@@ -483,7 +515,13 @@ public sealed partial class DeviceCardView : UserControl
     private void OnDeviceCardFlyoutOpening(object sender, object e)
     {
         if (sender is not MenuFlyout flyout || Card is not { } card) return;
-        if (!AllowContextMenu) { flyout.Hide(); return; }
+        if (!AllowContextMenu)
+        {
+            if (!QuickControlsMenu) { flyout.Hide(); return; }
+            flyout.Items.Clear();
+            flyout.Items.Add(BuildQuickControlsSettingsItem());
+            return;
+        }
         flyout.Items.Clear();
         AppendDeviceMenuItems(flyout.Items, card);
     }
@@ -535,6 +573,18 @@ public sealed partial class DeviceCardView : UserControl
         item.Click += click;
         return item;
     }
+
+    /// <summary>The Quick Controls flyout's sole item: restore the main window, jump to Settings, and
+    /// reveal the Quick Controls section. Built fresh per open, like the other menus.</summary>
+    private MenuFlyoutItem BuildQuickControlsSettingsItem()
+    {
+        var item = new MenuFlyoutItem { Text = "Settings", Icon = Glyph("") };
+        item.Click += OnQuickControlsSettingsClicked;
+        return item;
+    }
+
+    private void OnQuickControlsSettingsClicked(object sender, RoutedEventArgs e) =>
+        App.Current.OpenQuickControlsSettings();
 
     private static FontIcon Glyph(string glyph) => new() { Glyph = glyph };
 

--- a/src/Earmark.App/Controls/ReorderElevation.cs
+++ b/src/Earmark.App/Controls/ReorderElevation.cs
@@ -1,0 +1,114 @@
+using System.Runtime.CompilerServices;
+
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Hosting;
+using Microsoft.UI.Xaml.Media;
+
+using Windows.Foundation;
+using Windows.UI;
+
+namespace Earmark.App.Controls;
+
+/// <summary>
+/// Lifts a card while it slides to a new slot during a layout reflow or drag reorder, then settles it
+/// back. The card surface rests translucent (dark <c>LayerFillColorDefault</c> is ~30% opaque, so Mica
+/// bleeds through), which looks wrong mid-move: a card wrapping across another lets the one underneath
+/// read through it - its text and chrome bleed through the mover. While a card glides we raise it above
+/// its siblings (z-order) and force its surface fully opaque, so it cleanly occludes whatever it passes,
+/// reading as "lift, move, drop", then drop both back after the slide.
+///
+/// The opaque colour is the card's own resting brush with alpha forced to 255 (stays theme-correct);
+/// restoring it is a <see cref="DependencyObject.ClearValue"/> back to the themed brush, never a mutation
+/// of the shared resource. Only a diagonal move (both X and Y change) elevates - that's the row-wrap case
+/// where cards actually cross; a lockstep horizontal/vertical shift never overlaps, so it's left alone.
+/// </summary>
+internal static class ReorderElevation
+{
+    private const int ElevatedZ = 1;
+
+    // A touch longer than the 220ms Offset slide so the surface settles only once motion has stopped.
+    private static readonly TimeSpan SettleAfter = TimeSpan.FromMilliseconds(260);
+
+    private const double MoveEpsilon = 0.5;
+
+    private sealed class State
+    {
+        public Rect? LastRect;
+        public DispatcherQueueTimer? Timer;
+    }
+
+    private static readonly ConditionalWeakTable<UIElement, State> States = new();
+
+    /// <summary>Call once per arranged element, after <c>Arrange</c>. Detects whether the element moved
+    /// to a new slot this pass and, if the move is a diagonal (row-wrap) glide that will animate, lifts
+    /// it for the duration of the slide.</summary>
+    public static void TrackAndElevate(UIElement element, Rect newRect)
+    {
+        var state = States.GetOrCreateValue(element);
+        var prev = state.LastRect;
+        state.LastRect = newRect;
+
+        if (prev is not { } p) return;
+
+        var movedX = Math.Abs(p.X - newRect.X) > MoveEpsilon;
+        var movedY = Math.Abs(p.Y - newRect.Y) > MoveEpsilon;
+
+        // Only a diagonal move crosses other cards; and only animate-eligible elements (past their
+        // placement arrange, so the implicit Offset is attached) actually glide.
+        if (movedX && movedY &&
+            ElementCompositionPreview.GetElementVisual(element).ImplicitAnimations is not null)
+        {
+            Elevate(element, state);
+        }
+    }
+
+    private static void Elevate(UIElement element, State state)
+    {
+        if (state.Timer is null)
+        {
+            Canvas.SetZIndex(element, ElevatedZ);
+            ForceOpaque(element);
+
+            var timer = element.DispatcherQueue.CreateTimer();
+            timer.IsRepeating = false;
+            timer.Interval = SettleAfter;
+            timer.Tick += (_, _) =>
+            {
+                timer.Stop();
+                state.Timer = null;
+                Settle(element);
+            };
+            state.Timer = timer;
+            timer.Start();
+        }
+        else
+        {
+            // Already lifted and still sliding: push the settle out so back-to-back reflows
+            // don't drop it mid-glide.
+            state.Timer.Stop();
+            state.Timer.Start();
+        }
+    }
+
+    private static void ForceOpaque(UIElement element)
+    {
+        if (element is Border border &&
+            border.Background is SolidColorBrush brush &&
+            brush.Color.A < 255)
+        {
+            var c = brush.Color;
+            border.Background = new SolidColorBrush(Color.FromArgb(255, c.R, c.G, c.B));
+        }
+    }
+
+    private static void Settle(UIElement element)
+    {
+        Canvas.SetZIndex(element, 0);
+        if (element is Border border)
+        {
+            border.ClearValue(Border.BackgroundProperty);
+        }
+    }
+}

--- a/src/Earmark.App/Controls/WrapByRowLayout.cs
+++ b/src/Earmark.App/Controls/WrapByRowLayout.cs
@@ -233,7 +233,9 @@ public sealed class WrapByRowLayout : VirtualizingLayout
         for (var slot = 0; slot < display.Length; slot++)
         {
             if (display[slot] < 0) continue;   // phantom slot - nothing to arrange
-            context.GetOrCreateElementAt(display[slot]).Arrange(slotRects[slot]);
+            var element = context.GetOrCreateElementAt(display[slot]);
+            element.Arrange(slotRects[slot]);
+            ReorderElevation.TrackAndElevate(element, slotRects[slot]);
         }
 
         return new Size(finalSize.Width, totalHeight);

--- a/src/Earmark.App/MainWindow.xaml.cs
+++ b/src/Earmark.App/MainWindow.xaml.cs
@@ -29,6 +29,9 @@ public sealed partial class MainWindow : Window, IDisposable
     private BackdropMode? _appliedBackdrop;
     private bool _initialNavComplete;
     private DispatcherTimer? _toastTimer;
+    private string _defaultTitleBarTitle = "";
+    private string _defaultTitleBarSubtitle = "";
+    private TextBlock? _titleBarSubtitleTextBlock;
 
     public MainWindow(INavigationService navigation, IDispatcherQueueProvider dispatcher, ISettingsService settings, IUpdateService update, IInAppNotificationService inAppNotifications)
     {
@@ -42,6 +45,13 @@ public sealed partial class MainWindow : Window, IDisposable
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
         AppWindow.TitleBar.PreferredHeightOption = Microsoft.UI.Windowing.TitleBarHeightOption.Tall;
+
+        // Snapshot the XAML-declared title/subtitle so the visibility toggle can restore them, then
+        // keep the subtitle clear of the caption buttons as the window resizes.
+        _defaultTitleBarTitle = AppTitleBar.Title;
+        _defaultTitleBarSubtitle = AppTitleBar.Subtitle;
+        AppTitleBar.SizeChanged += (_, _) => UpdateSubtitleOverlap();
+        ApplyTitleBarText();
         // Absolute path: a packaged (MSIX) launch sets the working directory to System32, not the
         // install dir, so a relative "Assets/AppIcon.ico" resolves to nothing and the window/taskbar
         // icon goes blank. AppContext.BaseDirectory is the install dir in both packaged and unpackaged.
@@ -241,6 +251,7 @@ public sealed partial class MainWindow : Window, IDisposable
         {
             ApplyBackdrop();
             ApplyTheme();
+            ApplyTitleBarText();
         }
 
         if (DispatcherQueue.HasThreadAccess)
@@ -291,6 +302,53 @@ public sealed partial class MainWindow : Window, IDisposable
                 ? Color.FromArgb(255, 0x88, 0x88, 0x88)
                 : Color.FromArgb(255, 0x99, 0x99, 0x99);
         }
+    }
+
+    // ---- Title-bar text: a manual show/hide toggle, plus an automatic hide of the subtitle when the
+    // window is too narrow to fit it clear of the caption buttons. ----
+
+    private void ApplyTitleBarText()
+    {
+        var show = _settings.Current.ShowTitleBarText;
+        AppTitleBar.Title = show ? _defaultTitleBarTitle : string.Empty;
+        AppTitleBar.Subtitle = show ? _defaultTitleBarSubtitle : string.Empty;
+
+        // The subtitle's ActualWidth only settles after the next layout pass, so recompute overlap once
+        // it has.
+        DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, UpdateSubtitleOverlap);
+    }
+
+    // The WinUI TitleBar reserves room for the caption buttons but doesn't drop the subtitle when the
+    // window gets too narrow - it just slides under them. Hide it via opacity (so its layout stays
+    // measurable for the re-show check) the moment it would cross into the caption-button inset, with a
+    // small margin so not even a single character pokes through.
+    private void UpdateSubtitleOverlap()
+    {
+        if (!_settings.Current.ShowTitleBarText || string.IsNullOrEmpty(_defaultTitleBarSubtitle)) return;
+
+        _titleBarSubtitleTextBlock ??= FindDescendantTextBlock(AppTitleBar, _defaultTitleBarSubtitle);
+        if (_titleBarSubtitleTextBlock is null || AppTitleBar.ActualWidth <= 0) return;
+
+        var scale = AppTitleBar.XamlRoot?.RasterizationScale ?? 1.0;
+        var rightInset = (AppWindow?.TitleBar?.RightInset ?? 0) / scale;
+        const double safetyMargin = 8;
+        var available = AppTitleBar.ActualWidth - rightInset - safetyMargin;
+
+        var origin = _titleBarSubtitleTextBlock.TransformToVisual(AppTitleBar).TransformPoint(new Windows.Foundation.Point(0, 0));
+        var subtitleRight = origin.X + _titleBarSubtitleTextBlock.ActualWidth;
+        _titleBarSubtitleTextBlock.Opacity = subtitleRight > available ? 0 : 1;
+    }
+
+    private static TextBlock? FindDescendantTextBlock(DependencyObject root, string text)
+    {
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is TextBlock { } tb && tb.Text == text) return tb;
+            if (FindDescendantTextBlock(child, text) is { } found) return found;
+        }
+        return null;
     }
 
     // Applies the backdrop material from settings via a controller (not <Window.SystemBackdrop>) so

--- a/src/Earmark.App/Services/AppInfo.cs
+++ b/src/Earmark.App/Services/AppInfo.cs
@@ -83,6 +83,9 @@ internal static class AppInfo
     public static string NewBugUrl => $"{RepoUrl}/issues/new?template=bug_report.yml";
     public static string NewFeatureUrl => $"{RepoUrl}/issues/new?template=feature_request.yml";
 
+    /// <summary>PayPal donation link, surfaced from the About section.</summary>
+    public static string DonateUrl => "https://www.paypal.com/donate/?hosted_button_id=SWG4G7VH3ZFQN";
+
     /// <summary>
     /// Releases list (newest first). We read the list rather than <c>releases/latest</c> so a
     /// pre-release build can find the newest pre-release; stable builds just filter prereleases out.

--- a/src/Earmark.App/Services/WindowChromeManager.cs
+++ b/src/Earmark.App/Services/WindowChromeManager.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 
 using Earmark.App.Settings;
+using Earmark.App.ViewModels;
 
 using H.NotifyIcon;
 
@@ -25,7 +26,13 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
     private const uint WM_SYSCOMMAND = 0x0112;
     private const uint SC_MINIMIZE = 0xF020;
     private const uint WM_GETMINMAXINFO = 0x0024;
-    private const int MinWindowWidthDip = 440;
+    // One device-card column at its min width plus the Devices page side padding (DevicesScrollPadding,
+    // 16+16). At this width the NavigationView is in its minimal mode, so the content region spans the
+    // full window and a single card fits without clipping. Compact cards use a ~20%-narrower column
+    // (PeakMeterOptions.ColumnMinWidth), so the floor follows the live Compact setting.
+    private const int DevicesSidePaddingDip = 32;
+    private static int MinWindowWidthDip(bool compact) =>
+        (int)(compact ? PeakMeterOptions.CompactColumnMinWidth : PeakMeterOptions.DefaultColumnMinWidth) + DevicesSidePaddingDip;
     private const int MinWindowHeightDip = 340;
 
     private readonly ISettingsService _settings;
@@ -234,7 +241,7 @@ internal sealed class WindowChromeManager : IWindowChromeManager, IDisposable
             var dpi = GetDpiForWindow(hWnd);
             var scale = dpi == 0 ? 1.0 : dpi / 96.0;
             var mmi = Marshal.PtrToStructure<MINMAXINFO>(lParam);
-            mmi.ptMinTrackSize.x = (int)Math.Round(MinWindowWidthDip * scale);
+            mmi.ptMinTrackSize.x = (int)Math.Round(MinWindowWidthDip(_settings.Current.CompactCards) * scale);
             mmi.ptMinTrackSize.y = (int)Math.Round(MinWindowHeightDip * scale);
             Marshal.StructureToPtr(mmi, lParam, fDeleteOld: false);
             return 0;

--- a/src/Earmark.App/Settings/AppSettings.cs
+++ b/src/Earmark.App/Settings/AppSettings.cs
@@ -41,6 +41,28 @@ public sealed class AppSettings
 
     public QuickControlsDisplayMode QuickControlsDisplay { get; set; } = QuickControlsDisplayMode.CurrentlyActive;
 
+    // Quick Controls display overrides. The overlay is its own configurable view: these win over the
+    // matching Devices-page settings for the cards rendered in Quick Controls (the main window keeps the
+    // Devices-page settings). Defaults suit a dense, glanceable overlay.
+
+    /// <summary>Quick Controls: show each card's rules section. Default false (the overlay is for quick
+    /// volume/now-playing access, not rule editing).</summary>
+    public bool QuickControlsShowRules { get; set; }
+
+    /// <summary>Quick Controls: show the now-playing strip. Default true.</summary>
+    public bool QuickControlsShowNowPlaying { get; set; } = true;
+
+    /// <summary>Quick Controls: show the header badge row (flow / Default / Communications pills). Default false
+    /// (the dense overlay drops badges to keep cards short).</summary>
+    public bool QuickControlsShowDeviceBadges { get; set; }
+
+    /// <summary>Quick Controls: draw the hairline section dividers. Default false (the dense overlay relies on
+    /// spacing instead).</summary>
+    public bool QuickControlsShowDividers { get; set; }
+
+    /// <summary>Quick Controls: render cards in the compact layout. Default true.</summary>
+    public bool QuickControlsCompact { get; set; } = true;
+
     public bool VerboseLogging { get; set; }
 
     /// <summary>

--- a/src/Earmark.App/Settings/AppSettings.cs
+++ b/src/Earmark.App/Settings/AppSettings.cs
@@ -119,6 +119,21 @@ public sealed class AppSettings
     /// sections by spacing alone.</summary>
     public bool ShowCardDividers { get; set; } = true;
 
+    /// <summary>Whether device cards render in a denser layout: tighter padding and section spacing,
+    /// a smaller icon tile, and trimmed now-playing strips. Default false (the roomy layout). Applies
+    /// to both the Devices page and the Quick Controls overlay.</summary>
+    public bool CompactCards { get; set; }
+
+    /// <summary>Whether device cards show the header badges (the Input / Output flow label and the
+    /// Default / Communications / Disconnected pills). Default true; off hides the whole badge row and
+    /// frees that line of vertical space.</summary>
+    public bool ShowDeviceBadges { get; set; } = true;
+
+    /// <summary>Whether the title bar shows the app title and subtitle ("Earmark" / "Audio rules
+    /// engine"). Default true; off leaves only the icon and caption buttons. The subtitle also
+    /// auto-hides on its own when the window is too narrow to fit it clear of the caption buttons.</summary>
+    public bool ShowTitleBarText { get; set; } = true;
+
     /// <summary>Whether each device card shows its rules section. Default true; off hides the
     /// rules chips and no-rules text on every card.</summary>
     public bool ShowRules { get; set; } = true;
@@ -317,13 +332,17 @@ public sealed class DeviceConfig
     /// <summary>Override for the rules section (global <see cref="AppSettings.ShowRules"/>).</summary>
     public bool? ShowRules { get; set; }
 
+    /// <summary>Override for the header badge row (global <see cref="AppSettings.ShowDeviceBadges"/>).</summary>
+    public bool? ShowDeviceBadges { get; set; }
+
     /// <summary>True when every flag is unset/false, so the entry carries no information and can be
     /// pruned from the map on save. Not serialised (it's a derived helper, not stored state).</summary>
     [JsonIgnore]
     public bool IsDefault => Hidden is not true && Pinned is not true && VolumeControlsHidden is not true
         && PinnedToQuickControls is not true && Glyph is null && AccentColour is null
         && ShowNowPlaying is null && NowPlayingFill is null && ShowAppIndicators is null
-        && ShowAppMeters is null && MeterEnabled is null && ShowPeakIndicator is null && ShowRules is null;
+        && ShowAppMeters is null && MeterEnabled is null && ShowPeakIndicator is null && ShowRules is null
+        && ShowDeviceBadges is null;
 }
 
 /// <summary>

--- a/src/Earmark.App/ViewModels/AboutViewModel.cs
+++ b/src/Earmark.App/ViewModels/AboutViewModel.cs
@@ -72,12 +72,17 @@ public partial class AboutViewModel : ObservableObject, IDisposable
     /// never reach the network).</summary>
     public bool CanCheck => !IsChecking && !AppInfo.IsDevBuild;
 
+    /// <summary>Whether update checks run on this build at all. False on local (Dev) builds, where the
+    /// whole update section (manual check and auto-check) is read-only. Settings cards bind IsEnabled to
+    /// this so the section greys out as one, not just the buttons inside it.</summary>
+    public bool IsUpdateCheckEnabled => IsUpdateCheckSupported && !AppInfo.IsDevBuild;
+
     /// <summary>
     /// Whether the auto-check toggle is interactive. Off for local (Dev) builds: they never
     /// auto-check, and a dev build shares settings.json with a side-by-side live install, so the
     /// toggle stays read-only to avoid flipping that shared setting.
     /// </summary>
-    public bool IsAutoCheckEnabled => IsUpdateCheckSupported && !AppInfo.IsDevBuild;
+    public bool IsAutoCheckEnabled => IsUpdateCheckEnabled;
 
     public string AutoCheckDescription => IsAutoCheckEnabled
         ? "Earmark checks GitHub for a newer release when it starts."

--- a/src/Earmark.App/ViewModels/AboutViewModel.cs
+++ b/src/Earmark.App/ViewModels/AboutViewModel.cs
@@ -115,6 +115,8 @@ public partial class AboutViewModel : ObservableObject, IDisposable
 
     public void OpenGitHub() => OpenUrl(AppInfo.RepoUrl);
 
+    public void Donate() => OpenUrl(AppInfo.DonateUrl);
+
     public void OpenLogsFolder()
     {
         try

--- a/src/Earmark.App/ViewModels/CardPresentation.cs
+++ b/src/Earmark.App/ViewModels/CardPresentation.cs
@@ -1,0 +1,137 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Earmark.App.ViewModels;
+
+/// <summary>One now-playing strip paired with the view's display options, so the strip's data template
+/// (which can't reach the host control's options) renders at the right window's density. <see cref="Strip"/>
+/// is the shared strip VM (all live state); <see cref="Options"/> is this view's options.</summary>
+public sealed record NowPlayingStripView(NowPlayingStrip Strip, PeakMeterOptions Options);
+
+/// <summary>
+/// Per-view presentation of a <see cref="DeviceCard"/>: pairs the (shared) card with the display
+/// <see cref="PeakMeterOptions"/> for the window rendering it, and recomputes the visibility flags that
+/// combine an option with card data (rules / now-playing / badges / dividers / volume-row). The main
+/// window builds one with the card's global options; Quick Controls builds one with its own options, so
+/// the same card renders to each window's settings without duplicating the card. Pure styling/data reads,
+/// re-raised when either side changes; live data, commands, and per-device state stay on the card.
+/// </summary>
+public sealed partial class CardPresentation : ObservableObject, IDisposable
+{
+    private readonly DeviceCard _card;
+    private readonly PeakMeterOptions _options;
+
+    public CardPresentation(DeviceCard card, PeakMeterOptions options)
+    {
+        _card = card ?? throw new ArgumentNullException(nameof(card));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _card.PropertyChanged += OnCardChanged;
+        _options.PropertyChanged += OnOptionsChanged;
+        foreach (var strip in _card.NowPlayingStrips) NowPlayingStrips.Add(new NowPlayingStripView(strip, _options));
+        ((INotifyCollectionChanged)_card.NowPlayingStrips).CollectionChanged += OnStripsChanged;
+    }
+
+    /// <summary>The shared card (live data, commands, per-device state).</summary>
+    public DeviceCard Card => _card;
+
+    /// <summary>This view's display options (geometry + feature flags).</summary>
+    public PeakMeterOptions Options => _options;
+
+    /// <summary>The card's now-playing strips paired with this view's options, mirrored in place from
+    /// <see cref="DeviceCard.NowPlayingStrips"/>. The now-playing ItemsControl binds this so each strip's
+    /// data template gets the right window's density (the template can't see the host's Options DP).</summary>
+    public ObservableCollection<NowPlayingStripView> NowPlayingStrips { get; } = new();
+
+    private void OnStripsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        switch (e.Action)
+        {
+            case NotifyCollectionChangedAction.Add when e.NewItems is not null:
+                for (var i = 0; i < e.NewItems.Count; i++)
+                    NowPlayingStrips.Insert(e.NewStartingIndex + i, new NowPlayingStripView((NowPlayingStrip)e.NewItems[i]!, _options));
+                break;
+            case NotifyCollectionChangedAction.Remove when e.OldItems is not null:
+                for (var i = 0; i < e.OldItems.Count; i++) NowPlayingStrips.RemoveAt(e.OldStartingIndex);
+                break;
+            default:
+                NowPlayingStrips.Clear();
+                foreach (var strip in _card.NowPlayingStrips) NowPlayingStrips.Add(new NowPlayingStripView(strip, _options));
+                break;
+        }
+    }
+
+    private bool Compact => _options.CompactCards;
+
+    // ---- Rules ----
+    public bool ShowRulesSection => _options.ShowRules && _card.HasRules;
+    public bool ShowNoRulesMessage => _options.ShowRules && _card.HasNoRules;
+
+    // ---- Now playing ----
+    public bool ShowNowPlaying => _card.NowPlayingStrips.Count > 0 && _options.ShowNowPlaying;
+    public bool ShowCardBackground => _options.ShowNowPlaying && _options.NowPlayingCardBackground && _card.PrimaryNowPlaying is not null;
+
+    // ---- Apps row ----
+    public bool ShowAppsSection => _card.HasRowApps && _options.ShowAppIndicators;
+
+    // ---- Header badges ----
+    public bool ShowNormalBadges => _options.ShowDeviceBadges && !Compact;
+    public bool ShowCompactBadges => _options.ShowDeviceBadges && Compact;
+
+    // ---- Volume row ----
+    public bool ShowVolumeRow => _options.ShowMeter || _card.ShowVolumeControls;
+    public bool ShowPlainSlider => !_options.ShowMeter && _card.ShowVolumeControls;
+
+    // ---- Section dividers (mirror DeviceCard's original combine logic, sourced from this view's options) ----
+    public bool ShowNowPlayingDivider => _options.ShowCardDividers && ShowNowPlaying && ShowCardBackground;
+
+    public bool ShowAppsDivider => _options.ShowCardDividers && ShowAppsSection
+        && (ShowCardBackground || !ShowNowPlaying);
+
+    public bool ShowRulesDivider => _options.ShowCardDividers && (ShowRulesSection || ShowNoRulesMessage)
+        && !(ShowNowPlaying && !ShowCardBackground && !ShowAppsSection);
+
+    private void OnOptionsChanged(object? sender, PropertyChangedEventArgs e) => RaiseAll();
+
+    private void OnCardChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(DeviceCard.HasRules):
+            case nameof(DeviceCard.HasNoRules):
+            case nameof(DeviceCard.HasRowApps):
+            case nameof(DeviceCard.ShowVolumeControls):
+            case nameof(DeviceCard.PrimaryNowPlaying):
+            case nameof(DeviceCard.ShowNowPlaying):          // card raises this when strips reconcile
+            case nameof(DeviceCard.ShowAppsSection):
+            case nameof(DeviceCard.ShowCardBackground):
+                RaiseAll();
+                break;
+        }
+    }
+
+    private void RaiseAll()
+    {
+        OnPropertyChanged(nameof(ShowRulesSection));
+        OnPropertyChanged(nameof(ShowNoRulesMessage));
+        OnPropertyChanged(nameof(ShowNowPlaying));
+        OnPropertyChanged(nameof(ShowCardBackground));
+        OnPropertyChanged(nameof(ShowAppsSection));
+        OnPropertyChanged(nameof(ShowNormalBadges));
+        OnPropertyChanged(nameof(ShowCompactBadges));
+        OnPropertyChanged(nameof(ShowVolumeRow));
+        OnPropertyChanged(nameof(ShowPlainSlider));
+        OnPropertyChanged(nameof(ShowNowPlayingDivider));
+        OnPropertyChanged(nameof(ShowAppsDivider));
+        OnPropertyChanged(nameof(ShowRulesDivider));
+    }
+
+    public void Dispose()
+    {
+        _card.PropertyChanged -= OnCardChanged;
+        _options.PropertyChanged -= OnOptionsChanged;
+        ((INotifyCollectionChanged)_card.NowPlayingStrips).CollectionChanged -= OnStripsChanged;
+    }
+}

--- a/src/Earmark.App/ViewModels/DeviceCard.cs
+++ b/src/Earmark.App/ViewModels/DeviceCard.cs
@@ -151,6 +151,12 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     /// binding-site changes. Re-synced from the global template whenever either changes.</summary>
     public PeakMeterOptions MeterOptions { get; } = new();
 
+    /// <summary>The Quick Controls overlay's shared display options (the same instance for every card),
+    /// stamped by <c>HomeViewModel</c>. Not used by the card itself; the QC <c>DeviceCardView</c> binds
+    /// its <c>Options</c> to this so the overlay renders the card with the QC settings while the main
+    /// window uses the card's own (global) <see cref="MeterOptions"/>.</summary>
+    public PeakMeterOptions? QuickMeterOptions { get; set; }
+
     /// <summary>Folds the global options plus this device's overrides into <see cref="MeterOptions"/>.
     /// Style-only fields (colour / channels / card height / dividers / always-show-pinned) mirror the
     /// global verbatim; the six overridable display flags resolve as <c>override ?? global</c>.</summary>
@@ -270,8 +276,6 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         OnPropertyChanged(nameof(ShowCardBackground));
         // Section-divider toggle (and the rows they bracket) may have changed.
         NotifyDividersChanged();
-        // Compact toggle re-tightens padding / spacing / icon tile / strip geometry.
-        NotifyCompactLayoutChanged();
     }
 
     /// <summary>
@@ -452,106 +456,6 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     public bool HasMultipleRules => Rules.Count > 1;
     public bool ShowRulesSection => MeterOptions.ShowRules && HasRules;
     public bool ShowNoRulesMessage => MeterOptions.ShowRules && HasNoRules;
-
-    /// <summary>Whether the header badge row (flow label + Default / Communications / Disconnected
-    /// pills) shows in the <b>normal</b> layout: the badges feature is on and the card isn't compact
-    /// (compact moves the badges to their own full-width row below the header). Off frees that line.</summary>
-    public bool ShowNormalBadges => MeterOptions.ShowDeviceBadges && !Compact;
-
-    /// <summary>Whether the header badge row shows in the <b>compact</b> layout: the badges feature is
-    /// on and the card is compact. Off frees that row.</summary>
-    public bool ShowCompactBadges => MeterOptions.ShowDeviceBadges && Compact;
-
-    // ---- Compact-layout geometry (driven by MeterOptions.CompactCards) ----
-    //
-    // Compact tightens the card: less inner padding and section spacing, a smaller icon tile/glyph,
-    // and trimmed now-playing strips. The values are exposed as bindable card properties (rather than
-    // XAML resources) so the toggle re-flows every live card without a rebuild - NotifyMeterStyleChanged
-    // re-raises them. The edge-bleed margins keep the section dividers and now-playing band flush with
-    // whichever padding is in effect.
-
-    private bool Compact => MeterOptions.CompactCards;
-
-    /// <summary>True while the compact layout is active. Drives the compact-only header restructure in
-    /// the card view (pills hoisted to a full-width row below the icon/name); normal layout is unchanged.</summary>
-    public bool IsCompactLayout => Compact;
-
-    /// <summary>Inner padding of the card content stack (the card's "padding"). 16 roomy / 10 compact.</summary>
-    public Thickness CardContentPadding => Compact ? new Thickness(10) : new Thickness(16);
-
-    /// <summary>Vertical spacing between the card's sections (header / volume / now-playing / apps /
-    /// rules). 12 roomy / 8 compact.</summary>
-    public double CardSectionSpacing => Compact ? 8 : 12;
-
-    /// <summary>Square size of the device icon tile in the header. 56 roomy / 40 compact (compact sizes
-    /// the tile to the name + device-id two-line height so the glyph sits level with them).</summary>
-    public double IconTileSize => Compact ? 40 : 56;
-
-    /// <summary>Font size of the icon-tile glyph. 28 roomy / 22 compact.</summary>
-    public double IconGlyphSize => Compact ? 22 : 28;
-
-    /// <summary>Size of the Wave Link channel bitmap inside the icon tile. 40 roomy / 28 compact.</summary>
-    public double WaveLinkIconSize => Compact ? 28 : 40;
-
-    /// <summary>Margin for the section-divider hairlines: bleeds horizontally to the card edge (negating
-    /// the content padding) and pulls the following section up a touch. -16/-6 roomy / -10/-4 compact.</summary>
-    public Thickness SectionDividerMargin => Compact ? new Thickness(-10, 0, -10, -4) : new Thickness(-16, 0, -16, -6);
-
-    /// <summary>Horizontal-bleed margin for the full-bleed now-playing strip band (no vertical pull, so
-    /// the StackPanel spacing sits it apart). -16 roomy / -10 compact, matching the content padding.
-    /// (The strip's own inner padding lives on <see cref="PeakMeterOptions.NowPlayingStripPadding"/>,
-    /// bound from the strip template's own scope.)</summary>
-    public Thickness EdgeBleedMargin => Compact ? new Thickness(-10, 0, -10, 0) : new Thickness(-16, 0, -16, 0);
-
-    /// <summary>Height of the volume row (slider + meter band). 28 roomy / 24 compact - 24 leaves room
-    /// for the 14px thumb once it's lifted onto the slim meter (a shorter row clips the lifted thumb's
-    /// top); the meter itself still reads slim via the smaller <see cref="MeterTotalHeight"/>.</summary>
-    public double VolumeRowHeight => Compact ? 24 : 28;
-
-    /// <summary>Total stacked peak-meter height the channel bars divide between them (the
-    /// <see cref="Controls.ChannelPeakMeter.TotalHeightOverride"/>). 20 roomy / 14 compact - slim but
-    /// still a clear bar rather than a hairline.</summary>
-    public double MeterTotalHeight => Compact ? 14 : 20;
-
-    /// <summary>Margin of the meter-overlay volume slider. The slider keeps its fixed -2 RenderTransform
-    /// (which centres the thumb in the roomy layout); compact lifts it a little further via the top margin
-    /// to centre on the slimmer compact meter. With the taller 24px compact row the lift needed is small
-    /// (-2 top); the right inset (2) reserves the thumb's travel at 100%. Margin binds reliably and
-    /// updates live, unlike a RenderTransform.</summary>
-    public Thickness VolumeSliderMargin => Compact ? new Thickness(0, -2, 2, 0) : new Thickness(0, 0, 2, 0);
-
-
-    /// <summary>Padding inside the inline first-rule chip (shared with the expanded chips via
-    /// <see cref="PeakMeterOptions.RuleChipPadding"/>). 12,10 roomy / 8,6 compact.</summary>
-    public Thickness RuleChipPadding => MeterOptions.RuleChipPadding;
-
-    /// <summary>Spacing between the first-rule chip's name and status lines. 2 roomy / 1 compact.</summary>
-    public double RuleChipSpacing => MeterOptions.RuleChipSpacing;
-
-    /// <summary>Whether the "Rules" caption above the rule chips shows. Hidden in compact (the chip
-    /// names the rule) to save a line; always shown in the normal layout.</summary>
-    public bool ShowRulesCaption => !Compact;
-
-    /// <summary>Re-raises the compact-layout geometry after the compact setting changes.</summary>
-    private void NotifyCompactLayoutChanged()
-    {
-        OnPropertyChanged(nameof(IsCompactLayout));
-        OnPropertyChanged(nameof(CardContentPadding));
-        OnPropertyChanged(nameof(CardSectionSpacing));
-        OnPropertyChanged(nameof(IconTileSize));
-        OnPropertyChanged(nameof(IconGlyphSize));
-        OnPropertyChanged(nameof(WaveLinkIconSize));
-        OnPropertyChanged(nameof(SectionDividerMargin));
-        OnPropertyChanged(nameof(EdgeBleedMargin));
-        OnPropertyChanged(nameof(VolumeRowHeight));
-        OnPropertyChanged(nameof(MeterTotalHeight));
-        OnPropertyChanged(nameof(VolumeSliderMargin));
-        OnPropertyChanged(nameof(RuleChipPadding));
-        OnPropertyChanged(nameof(RuleChipSpacing));
-        OnPropertyChanged(nameof(ShowRulesCaption));
-        OnPropertyChanged(nameof(ShowNormalBadges));
-        OnPropertyChanged(nameof(ShowCompactBadges));
-    }
 
     // The slider is editable unless:
     //   - a volume rule pins the level, or

--- a/src/Earmark.App/ViewModels/DeviceCard.cs
+++ b/src/Earmark.App/ViewModels/DeviceCard.cs
@@ -53,6 +53,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     private bool? _meterEnabledOverride;
     private bool? _showPeakIndicatorOverride;
     private bool? _showRulesOverride;
+    private bool? _showDeviceBadgesOverride;
 
     private bool _suppressVolumeWrite;
     private float _leftHold;
@@ -95,6 +96,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         _meterEnabledOverride = snapshot.MeterEnabledOverride;
         _showPeakIndicatorOverride = snapshot.ShowPeakIndicatorOverride;
         _showRulesOverride = snapshot.ShowRulesOverride;
+        _showDeviceBadgesOverride = snapshot.ShowDeviceBadgesOverride;
         SyncEffectiveOptions();
         DeviceKey = snapshot.DeviceKey;
         Endpoint = snapshot.Endpoint;
@@ -122,6 +124,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         RuleMutedSource = snapshot.RuleMutedSource;
         RuleVolumeSource = snapshot.RuleVolumeSource;
         Rules = snapshot.Rules;
+        StampRuleOptions();
         for (var i = 1; i < Rules.Count; i++)
         {
             AdditionalRules.Add(Rules[i]);
@@ -166,11 +169,13 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         MeterOptions.SingleColour = g.SingleColour;
         MeterOptions.CardHeight = g.CardHeight;
         MeterOptions.ShowCardDividers = g.ShowCardDividers;
+        MeterOptions.CompactCards = g.CompactCards;
         MeterOptions.AlwaysShowPinnedApps = g.AlwaysShowPinnedApps;
         MeterOptions.ShowHold = _showPeakIndicatorOverride ?? g.ShowHold;
         MeterOptions.ShowAppIndicators = _showAppIndicatorsOverride ?? g.ShowAppIndicators;
         MeterOptions.ShowAppMeters = _showAppMetersOverride ?? g.ShowAppMeters;
         MeterOptions.ShowRules = _showRulesOverride ?? g.ShowRules;
+        MeterOptions.ShowDeviceBadges = _showDeviceBadgesOverride ?? g.ShowDeviceBadges;
         MeterOptions.ShowNowPlaying = _showNowPlayingOverride ?? g.ShowNowPlaying;
         MeterOptions.NowPlayingCardBackground = _nowPlayingFillOverride ?? g.NowPlayingCardBackground;
     }
@@ -198,6 +203,9 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     /// <summary>The rules-section override (null = follow global).</summary>
     public bool? ShowRulesOverride => _showRulesOverride;
 
+    /// <summary>The header-badge-row override (null = follow global).</summary>
+    public bool? ShowDeviceBadgesOverride => _showDeviceBadgesOverride;
+
     // Current global defaults for the six overridable flags, so the Customise dialog can label its
     // "Use global (On/Off)" option with what following the global would currently do.
     public bool GlobalShowNowPlaying => _globalOptions.ShowNowPlaying;
@@ -207,6 +215,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     public bool GlobalMeterEnabled => _globalOptions.ShowMeter;
     public bool GlobalShowPeakIndicator => _globalOptions.ShowHold;
     public bool GlobalShowRules => _globalOptions.ShowRules;
+    public bool GlobalShowDeviceBadges => _globalOptions.ShowDeviceBadges;
 
     /// <summary>Sets the per-device display overrides without persisting (used by the in-place
     /// rebuild and the Settings "Clear overrides" path, which re-reads from the saved config).
@@ -214,7 +223,8 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     /// override actually changed, so the caller can decide whether to re-run the apps reconcile.</summary>
     public bool ApplyFeatureOverrides(
         bool? showNowPlaying, bool? nowPlayingFill, bool? showAppIndicators,
-        bool? showAppMeters, bool? meterEnabled, bool? showPeakIndicator, bool? showRules)
+        bool? showAppMeters, bool? meterEnabled, bool? showPeakIndicator, bool? showRules,
+        bool? showDeviceBadges)
     {
         var changed =
             _showNowPlayingOverride != showNowPlaying
@@ -223,7 +233,8 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
             || _showAppMetersOverride != showAppMeters
             || _meterEnabledOverride != meterEnabled
             || _showPeakIndicatorOverride != showPeakIndicator
-            || _showRulesOverride != showRules;
+            || _showRulesOverride != showRules
+            || _showDeviceBadgesOverride != showDeviceBadges;
         if (!changed) return false;
 
         _showNowPlayingOverride = showNowPlaying;
@@ -233,6 +244,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         _meterEnabledOverride = meterEnabled;
         _showPeakIndicatorOverride = showPeakIndicator;
         _showRulesOverride = showRules;
+        _showDeviceBadgesOverride = showDeviceBadges;
         NotifyMeterStyleChanged();
         return true;
     }
@@ -258,6 +270,8 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         OnPropertyChanged(nameof(ShowCardBackground));
         // Section-divider toggle (and the rows they bracket) may have changed.
         NotifyDividersChanged();
+        // Compact toggle re-tightens padding / spacing / icon tile / strip geometry.
+        NotifyCompactLayoutChanged();
     }
 
     /// <summary>
@@ -438,6 +452,106 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
     public bool HasMultipleRules => Rules.Count > 1;
     public bool ShowRulesSection => MeterOptions.ShowRules && HasRules;
     public bool ShowNoRulesMessage => MeterOptions.ShowRules && HasNoRules;
+
+    /// <summary>Whether the header badge row (flow label + Default / Communications / Disconnected
+    /// pills) shows in the <b>normal</b> layout: the badges feature is on and the card isn't compact
+    /// (compact moves the badges to their own full-width row below the header). Off frees that line.</summary>
+    public bool ShowNormalBadges => MeterOptions.ShowDeviceBadges && !Compact;
+
+    /// <summary>Whether the header badge row shows in the <b>compact</b> layout: the badges feature is
+    /// on and the card is compact. Off frees that row.</summary>
+    public bool ShowCompactBadges => MeterOptions.ShowDeviceBadges && Compact;
+
+    // ---- Compact-layout geometry (driven by MeterOptions.CompactCards) ----
+    //
+    // Compact tightens the card: less inner padding and section spacing, a smaller icon tile/glyph,
+    // and trimmed now-playing strips. The values are exposed as bindable card properties (rather than
+    // XAML resources) so the toggle re-flows every live card without a rebuild - NotifyMeterStyleChanged
+    // re-raises them. The edge-bleed margins keep the section dividers and now-playing band flush with
+    // whichever padding is in effect.
+
+    private bool Compact => MeterOptions.CompactCards;
+
+    /// <summary>True while the compact layout is active. Drives the compact-only header restructure in
+    /// the card view (pills hoisted to a full-width row below the icon/name); normal layout is unchanged.</summary>
+    public bool IsCompactLayout => Compact;
+
+    /// <summary>Inner padding of the card content stack (the card's "padding"). 16 roomy / 10 compact.</summary>
+    public Thickness CardContentPadding => Compact ? new Thickness(10) : new Thickness(16);
+
+    /// <summary>Vertical spacing between the card's sections (header / volume / now-playing / apps /
+    /// rules). 12 roomy / 8 compact.</summary>
+    public double CardSectionSpacing => Compact ? 8 : 12;
+
+    /// <summary>Square size of the device icon tile in the header. 56 roomy / 40 compact (compact sizes
+    /// the tile to the name + device-id two-line height so the glyph sits level with them).</summary>
+    public double IconTileSize => Compact ? 40 : 56;
+
+    /// <summary>Font size of the icon-tile glyph. 28 roomy / 22 compact.</summary>
+    public double IconGlyphSize => Compact ? 22 : 28;
+
+    /// <summary>Size of the Wave Link channel bitmap inside the icon tile. 40 roomy / 28 compact.</summary>
+    public double WaveLinkIconSize => Compact ? 28 : 40;
+
+    /// <summary>Margin for the section-divider hairlines: bleeds horizontally to the card edge (negating
+    /// the content padding) and pulls the following section up a touch. -16/-6 roomy / -10/-4 compact.</summary>
+    public Thickness SectionDividerMargin => Compact ? new Thickness(-10, 0, -10, -4) : new Thickness(-16, 0, -16, -6);
+
+    /// <summary>Horizontal-bleed margin for the full-bleed now-playing strip band (no vertical pull, so
+    /// the StackPanel spacing sits it apart). -16 roomy / -10 compact, matching the content padding.
+    /// (The strip's own inner padding lives on <see cref="PeakMeterOptions.NowPlayingStripPadding"/>,
+    /// bound from the strip template's own scope.)</summary>
+    public Thickness EdgeBleedMargin => Compact ? new Thickness(-10, 0, -10, 0) : new Thickness(-16, 0, -16, 0);
+
+    /// <summary>Height of the volume row (slider + meter band). 28 roomy / 24 compact - 24 leaves room
+    /// for the 14px thumb once it's lifted onto the slim meter (a shorter row clips the lifted thumb's
+    /// top); the meter itself still reads slim via the smaller <see cref="MeterTotalHeight"/>.</summary>
+    public double VolumeRowHeight => Compact ? 24 : 28;
+
+    /// <summary>Total stacked peak-meter height the channel bars divide between them (the
+    /// <see cref="Controls.ChannelPeakMeter.TotalHeightOverride"/>). 20 roomy / 14 compact - slim but
+    /// still a clear bar rather than a hairline.</summary>
+    public double MeterTotalHeight => Compact ? 14 : 20;
+
+    /// <summary>Margin of the meter-overlay volume slider. The slider keeps its fixed -2 RenderTransform
+    /// (which centres the thumb in the roomy layout); compact lifts it a little further via the top margin
+    /// to centre on the slimmer compact meter. With the taller 24px compact row the lift needed is small
+    /// (-2 top); the right inset (2) reserves the thumb's travel at 100%. Margin binds reliably and
+    /// updates live, unlike a RenderTransform.</summary>
+    public Thickness VolumeSliderMargin => Compact ? new Thickness(0, -2, 2, 0) : new Thickness(0, 0, 2, 0);
+
+
+    /// <summary>Padding inside the inline first-rule chip (shared with the expanded chips via
+    /// <see cref="PeakMeterOptions.RuleChipPadding"/>). 12,10 roomy / 8,6 compact.</summary>
+    public Thickness RuleChipPadding => MeterOptions.RuleChipPadding;
+
+    /// <summary>Spacing between the first-rule chip's name and status lines. 2 roomy / 1 compact.</summary>
+    public double RuleChipSpacing => MeterOptions.RuleChipSpacing;
+
+    /// <summary>Whether the "Rules" caption above the rule chips shows. Hidden in compact (the chip
+    /// names the rule) to save a line; always shown in the normal layout.</summary>
+    public bool ShowRulesCaption => !Compact;
+
+    /// <summary>Re-raises the compact-layout geometry after the compact setting changes.</summary>
+    private void NotifyCompactLayoutChanged()
+    {
+        OnPropertyChanged(nameof(IsCompactLayout));
+        OnPropertyChanged(nameof(CardContentPadding));
+        OnPropertyChanged(nameof(CardSectionSpacing));
+        OnPropertyChanged(nameof(IconTileSize));
+        OnPropertyChanged(nameof(IconGlyphSize));
+        OnPropertyChanged(nameof(WaveLinkIconSize));
+        OnPropertyChanged(nameof(SectionDividerMargin));
+        OnPropertyChanged(nameof(EdgeBleedMargin));
+        OnPropertyChanged(nameof(VolumeRowHeight));
+        OnPropertyChanged(nameof(MeterTotalHeight));
+        OnPropertyChanged(nameof(VolumeSliderMargin));
+        OnPropertyChanged(nameof(RuleChipPadding));
+        OnPropertyChanged(nameof(RuleChipSpacing));
+        OnPropertyChanged(nameof(ShowRulesCaption));
+        OnPropertyChanged(nameof(ShowNormalBadges));
+        OnPropertyChanged(nameof(ShowCompactBadges));
+    }
 
     // The slider is editable unless:
     //   - a volume rule pins the level, or
@@ -879,6 +993,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         RuleVolumeSource = summary.RuleVolumeSource;
 
         Rules = summary.Rules;
+        StampRuleOptions();
         AdditionalRules.Clear();
         for (var i = 1; i < Rules.Count; i++) AdditionalRules.Add(Rules[i]);
 
@@ -890,6 +1005,14 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         OnPropertyChanged(nameof(ShowRulesDivider));
         OnPropertyChanged(nameof(FirstRule));
         OnPropertyChanged(nameof(AdditionalRulesLabel));
+    }
+
+    /// <summary>Stamps this card's effective <see cref="MeterOptions"/> onto each rule summary so the
+    /// RuleSummary-scoped chip template can bind the (live) compact rule-chip geometry. The first-rule
+    /// chip binds the card's own properties; the expanded chips rely on this.</summary>
+    private void StampRuleOptions()
+    {
+        foreach (var rule in Rules) rule.Options = MeterOptions;
     }
 
     /// <summary>
@@ -923,6 +1046,7 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         RuleVolumeSource = snapshot.RuleVolumeSource;
 
         Rules = snapshot.Rules;
+        StampRuleOptions();
         AdditionalRules.Clear();
         for (var i = 1; i < Rules.Count; i++) AdditionalRules.Add(Rules[i]);
 
@@ -941,7 +1065,8 @@ public partial class DeviceCard : ObservableObject, IBlockLayoutInfo
         ApplyFeatureOverrides(
             snapshot.ShowNowPlayingOverride, snapshot.NowPlayingFillOverride,
             snapshot.ShowAppIndicatorsOverride, snapshot.ShowAppMetersOverride,
-            snapshot.MeterEnabledOverride, snapshot.ShowPeakIndicatorOverride, snapshot.ShowRulesOverride);
+            snapshot.MeterEnabledOverride, snapshot.ShowPeakIndicatorOverride, snapshot.ShowRulesOverride,
+            snapshot.ShowDeviceBadgesOverride);
 
         // Endpoint-derived bindings (defaults can shift, the id can change on reinstall). The
         // observable setters above already raised their own dependents; these are the non-observable

--- a/src/Earmark.App/ViewModels/DeviceCardSnapshot.cs
+++ b/src/Earmark.App/ViewModels/DeviceCardSnapshot.cs
@@ -41,4 +41,5 @@ public sealed record DeviceCardSnapshot(
     bool? ShowAppMetersOverride,
     bool? MeterEnabledOverride,
     bool? ShowPeakIndicatorOverride,
-    bool? ShowRulesOverride);
+    bool? ShowRulesOverride,
+    bool? ShowDeviceBadgesOverride);

--- a/src/Earmark.App/ViewModels/DeviceGroupCard.cs
+++ b/src/Earmark.App/ViewModels/DeviceGroupCard.cs
@@ -22,10 +22,11 @@ public partial class DeviceGroupCard : ObservableObject, IBlockLayoutInfo
     private readonly bool _hideEmptyTitleBand;
     private bool _suppressChanged;
 
-    public DeviceGroupCard(string id, string title, Action<DeviceGroupCard>? onChanged, bool hideEmptyTitleBand = false)
+    public DeviceGroupCard(string id, string title, Action<DeviceGroupCard>? onChanged, PeakMeterOptions meterOptions, bool hideEmptyTitleBand = false)
     {
         Id = id;
         _hideEmptyTitleBand = hideEmptyTitleBand;
+        MeterOptions = meterOptions;
         _suppressChanged = true;
         Title = title;
         _suppressChanged = false;
@@ -34,6 +35,11 @@ public partial class DeviceGroupCard : ObservableObject, IBlockLayoutInfo
 
     /// <summary>Stable group id (matches <c>DeviceGroup.Id</c> and the group's slot in the block order).</summary>
     public string Id { get; }
+
+    /// <summary>The shared meter/display options. Bound by the nested members <see cref="WrapByRowLayout"/>
+    /// for its <c>MinItemWidth</c> (<see cref="PeakMeterOptions.ColumnMinWidth"/>), so the group's members
+    /// use the same compact-aware column width as lone cards and stay aligned to them.</summary>
+    public PeakMeterOptions MeterOptions { get; }
 
     /// <summary>The member cards, in left-to-right member order. Mutated in place (Remove/Insert,
     /// never Move - <see cref="WrapByRowLayout"/> ignores Move) so instances are preserved.</summary>

--- a/src/Earmark.App/ViewModels/DeviceRulesSummary.cs
+++ b/src/Earmark.App/ViewModels/DeviceRulesSummary.cs
@@ -17,6 +17,12 @@ public sealed record RuleSummary(
 {
     public bool HasMatchSummary => !string.IsNullOrEmpty(MatchSummary);
 
+    /// <summary>Shared display options, stamped by the owning <see cref="DeviceCard"/> so the
+    /// RuleSummary-scoped chip template can bind the compact rule-chip geometry
+    /// (<see cref="PeakMeterOptions.RuleChipPadding"/> / <see cref="PeakMeterOptions.RuleChipSpacing"/>)
+    /// and update live with the compact toggle. Not set by the pure summary builder; null until stamped.</summary>
+    public PeakMeterOptions? Options { get; set; }
+
     /// <summary>Same dim-out logic the Rules page uses for non-active rules.</summary>
     public double Opacity => Status switch
     {

--- a/src/Earmark.App/ViewModels/HomeViewModel.cs
+++ b/src/Earmark.App/ViewModels/HomeViewModel.cs
@@ -88,11 +88,20 @@ public partial class HomeViewModel : ObservableObject, IDisposable
     private readonly Dictionary<string, List<uint>> _tickPidsByAppKey = new(StringComparer.Ordinal);
     private readonly HashSet<string> _tickSeenAppsOnCard = new(StringComparer.Ordinal);
     private readonly PeakMeterOptions _meterOptions = new();
+    // A complete second options set for the Quick Controls overlay: every field mirrors the global
+    // options except the handful the QC settings override (rules / now-playing / badges / dividers /
+    // compact). The QC DeviceCardViews bind their Options to this, so the overlay is configured
+    // independently of the Devices page without duplicating the cards.
+    private readonly PeakMeterOptions _quickMeterOptions = new();
     private readonly DeviceUndoStack _undoStack = new();
 
     /// <summary>The shared meter/display options. Exposed so the page's <see cref="Controls.BlockWrapLayout"/>
     /// can bind its compact-aware <c>MinItemWidth</c> (<see cref="PeakMeterOptions.ColumnMinWidth"/>).</summary>
     public PeakMeterOptions MeterOptions => _meterOptions;
+
+    /// <summary>The Quick Controls overlay's display options (Devices-page settings with the QC overrides
+    /// applied). The overlay's cards bind <c>DeviceCardView.Options</c> to this.</summary>
+    public PeakMeterOptions QuickMeterOptions => _quickMeterOptions;
 
     // Effective-flag fans across cards: true when the feature is on globally OR forced on for any
     // device. Each card's MeterOptions already resolves override-or-global, so these just OR them.
@@ -990,6 +999,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
                     OnCardVisibilityToggled, OnCardQuickPinToggled, OnCardCustomisationChanged,
                     OnCardBluetoothToggle);
             }
+            card.QuickMeterOptions = _quickMeterOptions;
             rebuilt.Add(card);
         }
 
@@ -1075,6 +1085,31 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         _meterOptions.ShowNowPlaying = s.ShowNowPlaying;
         _meterOptions.NowPlayingCardBackground = s.NowPlayingCardBackground;
         foreach (var card in _allCards) card.NotifyMeterStyleChanged();
+        SyncQuickMeterOptions(s);
+    }
+
+    /// <summary>Mirrors the global options onto <see cref="_quickMeterOptions"/>, then applies the Quick
+    /// Controls overrides. The overlay's cards bind this, so QC's rules / now-playing / badges / dividers /
+    /// compact differ from the Devices page while everything else (meter colour, app chips, ...) matches.</summary>
+    private void SyncQuickMeterOptions(AppSettings s)
+    {
+        var q = _quickMeterOptions;
+        // Mirror everything from the global set...
+        q.ColourMode = _meterOptions.ColourMode;
+        q.ChannelMode = _meterOptions.ChannelMode;
+        q.ShowHold = _meterOptions.ShowHold;
+        q.SingleColour = _meterOptions.SingleColour;
+        q.ShowAppIndicators = _meterOptions.ShowAppIndicators;
+        q.ShowAppMeters = _meterOptions.ShowAppMeters;
+        q.AlwaysShowPinnedApps = _meterOptions.AlwaysShowPinnedApps;
+        q.CardHeight = _meterOptions.CardHeight;
+        q.NowPlayingCardBackground = _meterOptions.NowPlayingCardBackground;
+        // ...then override the five QC-specific knobs.
+        q.CompactCards = s.QuickControlsCompact;
+        q.ShowRules = s.QuickControlsShowRules;
+        q.ShowNowPlaying = s.QuickControlsShowNowPlaying;
+        q.ShowDeviceBadges = s.QuickControlsShowDeviceBadges;
+        q.ShowCardDividers = s.QuickControlsShowDividers;
     }
 
     /// <summary>

--- a/src/Earmark.App/ViewModels/HomeViewModel.cs
+++ b/src/Earmark.App/ViewModels/HomeViewModel.cs
@@ -90,6 +90,10 @@ public partial class HomeViewModel : ObservableObject, IDisposable
     private readonly PeakMeterOptions _meterOptions = new();
     private readonly DeviceUndoStack _undoStack = new();
 
+    /// <summary>The shared meter/display options. Exposed so the page's <see cref="Controls.BlockWrapLayout"/>
+    /// can bind its compact-aware <c>MinItemWidth</c> (<see cref="PeakMeterOptions.ColumnMinWidth"/>).</summary>
+    public PeakMeterOptions MeterOptions => _meterOptions;
+
     // Effective-flag fans across cards: true when the feature is on globally OR forced on for any
     // device. Each card's MeterOptions already resolves override-or-global, so these just OR them.
     // Used to decide whether the (global) build/tick passes need to run at all.
@@ -212,6 +216,9 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         ShowDisconnectedDevices = _settings.Current.ShowDisconnectedDevices;
         ShowDevicesHeader = _settings.Current.ShowDevicesPageHeader;
         ShowRules = _settings.Current.ShowRules;
+        ShowCardDividers = _settings.Current.ShowCardDividers;
+        ShowDeviceBadges = _settings.Current.ShowDeviceBadges;
+        CompactCards = _settings.Current.CompactCards;
         LockLayout = _settings.Current.LockDeviceLayout;
 
         IsInitializing = true;
@@ -316,6 +323,46 @@ public partial class HomeViewModel : ObservableObject, IDisposable
     {
         if (_settings.Current.ShowRules == value) return;
         _settings.Current.ShowRules = value;
+        SyncMeterOptions();
+        QueueSettingsSave();
+    }
+
+    /// <summary>Whether device cards draw hairline section dividers. Persisted; toggled from the Devices
+    /// page background menu and the "..." menu (and the Settings page).</summary>
+    [ObservableProperty]
+    public partial bool ShowCardDividers { get; set; }
+
+    partial void OnShowCardDividersChanged(bool value)
+    {
+        if (_settings.Current.ShowCardDividers == value) return;
+        _settings.Current.ShowCardDividers = value;
+        SyncMeterOptions();
+        QueueSettingsSave();
+    }
+
+    /// <summary>Whether device cards show the header badge row (flow label + Default / Communications /
+    /// Disconnected pills). Persisted; toggled from the Devices page background menu and the "..." menu
+    /// (and the Settings page).</summary>
+    [ObservableProperty]
+    public partial bool ShowDeviceBadges { get; set; }
+
+    partial void OnShowDeviceBadgesChanged(bool value)
+    {
+        if (_settings.Current.ShowDeviceBadges == value) return;
+        _settings.Current.ShowDeviceBadges = value;
+        SyncMeterOptions();
+        QueueSettingsSave();
+    }
+
+    /// <summary>Whether device cards use the denser compact layout. Persisted; toggled from the Devices
+    /// page background menu and the "..." menu (and the Settings page).</summary>
+    [ObservableProperty]
+    public partial bool CompactCards { get; set; }
+
+    partial void OnCompactCardsChanged(bool value)
+    {
+        if (_settings.Current.CompactCards == value) return;
+        _settings.Current.CompactCards = value;
         SyncMeterOptions();
         QueueSettingsSave();
     }
@@ -958,6 +1005,18 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             {
                 ShowRules = _settings.Current.ShowRules;
             }
+            if (CompactCards != _settings.Current.CompactCards)
+            {
+                CompactCards = _settings.Current.CompactCards;
+            }
+            if (ShowCardDividers != _settings.Current.ShowCardDividers)
+            {
+                ShowCardDividers = _settings.Current.ShowCardDividers;
+            }
+            if (ShowDeviceBadges != _settings.Current.ShowDeviceBadges)
+            {
+                ShowDeviceBadges = _settings.Current.ShowDeviceBadges;
+            }
             SyncMeterOptions();
             // Re-read each card's per-device display overrides from the (possibly just-rewritten)
             // config. This is the path by which a Settings "Clear overrides" reset reaches the live
@@ -1010,7 +1069,9 @@ public partial class HomeViewModel : ObservableObject, IDisposable
         _meterOptions.AlwaysShowPinnedApps = s.AlwaysShowPinnedApps;
         _meterOptions.CardHeight = s.CardHeight;
         _meterOptions.ShowCardDividers = s.ShowCardDividers;
+        _meterOptions.CompactCards = s.CompactCards;
         _meterOptions.ShowRules = s.ShowRules;
+        _meterOptions.ShowDeviceBadges = s.ShowDeviceBadges;
         _meterOptions.ShowNowPlaying = s.ShowNowPlaying;
         _meterOptions.NowPlayingCardBackground = s.NowPlayingCardBackground;
         foreach (var card in _allCards) card.NotifyMeterStyleChanged();
@@ -1352,7 +1413,8 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             ShowAppMetersOverride: cfg?.ShowAppMeters,
             MeterEnabledOverride: cfg?.MeterEnabled,
             ShowPeakIndicatorOverride: cfg?.ShowPeakIndicator,
-            ShowRulesOverride: cfg?.ShowRules);
+            ShowRulesOverride: cfg?.ShowRules,
+            ShowDeviceBadgesOverride: cfg?.ShowDeviceBadges);
 
     /// <summary>
     /// Seeds / refreshes the known-devices table from the live endpoints, then prunes it (age-out
@@ -1583,7 +1645,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
 
             if (!_groupCards.TryGetValue(group.Id, out var gc))
             {
-                gc = new DeviceGroupCard(group.Id, group.Title, OnGroupCardChanged);
+                gc = new DeviceGroupCard(group.Id, group.Title, OnGroupCardChanged, _meterOptions);
                 _groupCards[group.Id] = gc;
             }
             else
@@ -1752,7 +1814,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
     {
         if (!_quickGroupCards.TryGetValue(key, out var group))
         {
-            group = new DeviceGroupCard($"quick-{key}", title, null, hideEmptyTitleBand);
+            group = new DeviceGroupCard($"quick-{key}", title, null, _meterOptions, hideEmptyTitleBand);
             _quickGroupCards[key] = group;
         }
 
@@ -2197,7 +2259,8 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             var cfg = LookupConfig(configs, card.DeviceKey, card.Endpoint.Id);
             if (card.ApplyFeatureOverrides(
                 cfg?.ShowNowPlaying, cfg?.NowPlayingFill, cfg?.ShowAppIndicators,
-                cfg?.ShowAppMeters, cfg?.MeterEnabled, cfg?.ShowPeakIndicator, cfg?.ShowRules))
+                cfg?.ShowAppMeters, cfg?.MeterEnabled, cfg?.ShowPeakIndicator, cfg?.ShowRules,
+                cfg?.ShowDeviceBadges))
             {
                 anyChanged = true;
             }
@@ -2342,6 +2405,7 @@ public partial class HomeViewModel : ObservableObject, IDisposable
             MeterEnabled = card.MeterEnabledOverride,
             ShowPeakIndicator = card.ShowPeakIndicatorOverride,
             ShowRules = card.ShowRulesOverride,
+            ShowDeviceBadges = card.ShowDeviceBadgesOverride,
         };
         if (cfg.IsDefault) map.Remove(card.DeviceKey);
         else map[card.DeviceKey] = cfg;

--- a/src/Earmark.App/ViewModels/PeakMeterOptions.cs
+++ b/src/Earmark.App/ViewModels/PeakMeterOptions.cs
@@ -61,11 +61,51 @@ public partial class PeakMeterOptions : ObservableObject
     [ObservableProperty]
     public partial bool CompactCards { get; set; }
 
+    // ---- Card-shell compact geometry ----
+    // Homed here (not on DeviceCard) so a per-view options object drives them: the main window binds the
+    // card's global options, Quick Controls binds its own, and the same card renders at either density.
+    // Roomy values are unchanged from the pre-refactor DeviceCard getters.
+
+    /// <summary>Inner padding of the card content stack. 16 roomy / 10 compact.</summary>
+    public Thickness CardContentPadding => CompactCards ? new Thickness(10) : new Thickness(16);
+
+    /// <summary>Vertical spacing between card sections. 12 roomy / 8 compact.</summary>
+    public double CardSectionSpacing => CompactCards ? 8 : 12;
+
+    /// <summary>Device icon tile size. 56 roomy / 40 compact.</summary>
+    public double IconTileSize => CompactCards ? 40 : 56;
+
+    /// <summary>Icon-tile glyph size. 28 roomy / 22 compact.</summary>
+    public double IconGlyphSize => CompactCards ? 22 : 28;
+
+    /// <summary>Wave Link channel bitmap size in the tile. 40 roomy / 28 compact.</summary>
+    public double WaveLinkIconSize => CompactCards ? 28 : 40;
+
+    /// <summary>Section-divider hairline margin (bleeds to the card edge, pulls the next section up).
+    /// -16/-6 roomy / -10/-4 compact.</summary>
+    public Thickness SectionDividerMargin => CompactCards ? new Thickness(-10, 0, -10, -4) : new Thickness(-16, 0, -16, -6);
+
+    /// <summary>Horizontal-bleed margin for the full-bleed now-playing band. -16 roomy / -10 compact.</summary>
+    public Thickness EdgeBleedMargin => CompactCards ? new Thickness(-10, 0, -10, 0) : new Thickness(-16, 0, -16, 0);
+
+    /// <summary>Volume row height. 28 roomy / 24 compact.</summary>
+    public double VolumeRowHeight => CompactCards ? 24 : 28;
+
+    /// <summary>Stacked peak-meter total height. 20 roomy / 14 compact.</summary>
+    public double MeterTotalHeight => CompactCards ? 14 : 20;
+
+    /// <summary>Meter-overlay volume slider margin (with a compact top-lift so the thumb centres on the
+    /// slim meter). 0,0,2,0 roomy / 0,-2,2,0 compact.</summary>
+    public Thickness VolumeSliderMargin => CompactCards ? new Thickness(0, -2, 2, 0) : new Thickness(0, 0, 2, 0);
+
+    /// <summary>Whether the "Rules" caption above the rule chips shows. Hidden in compact.</summary>
+    public bool ShowRulesCaption => !CompactCards;
+
     /// <summary>Inner padding of each now-playing strip in the current density. The strip band bleeds to
     /// the card edge, so the horizontal inset re-aligns its content to the card padding (16 roomy / 10
     /// compact). Bound from the strip template's own scope; re-raised when <see cref="CompactCards"/>
     /// flips, since the shared options instance (not the per-card properties) backs the strip template.</summary>
-    public Thickness NowPlayingStripPadding => CompactCards ? new Thickness(10, 8, 10, 4) : new Thickness(16, 12, 16, 6);
+    public Thickness NowPlayingStripPadding => CompactCards ? new Thickness(10, 4, 10, 2) : new Thickness(16, 12, 16, 6);
 
     /// <summary>Padding inside a rule summary chip. 12,10 roomy / 8,6 compact. Lives here (not just on
     /// the card) so the expanded additional-rules chips - whose template is RuleSummary-scoped - can
@@ -86,12 +126,79 @@ public partial class PeakMeterOptions : ObservableObject
     public const double DefaultColumnMinWidth = 320;
     public const double CompactColumnMinWidth = 256;
 
+    /// <summary>Top gap above a now-playing strip's title block. Roomy separates the title from the
+    /// app-name/meter line above it (6px); compact hides that line and hoists the title to the top, so
+    /// no gap. Bound from the strip template's own scope so it updates live with the toggle.</summary>
+    public Thickness NowPlayingTitleMargin => CompactCards ? new Thickness(0) : new Thickness(0, 6, 0, 0);
+
+    // Now-playing transport-control sizing. Compact shrinks the play/skip buttons so they're no taller
+    // than the title+artist block, otherwise the buttons drive the strip height (the "extra row" effect).
+    public double NowPlayingPlaySize => CompactCards ? 30 : 36;
+    public CornerRadius NowPlayingPlayCorner => new(CompactCards ? 15 : 18);
+    public double NowPlayingPlayGlyph => CompactCards ? 14 : 16;
+    public double NowPlayingSkipSize => CompactCards ? 28 : 32;
+    public CornerRadius NowPlayingSkipCorner => new(CompactCards ? 14 : 16);
+    public double NowPlayingSkipGlyph => CompactCards ? 12 : 14;
+
+    // Transport placement. Roomy spans the app-name row + title row and centres across both; compact
+    // hides the app-name row, so the controls sit in the title row only and centre with the title+artist
+    // (otherwise they centre against the empty header space and read too high).
+    public int NowPlayingControlsRow => CompactCards ? 1 : 0;
+    public int NowPlayingControlsRowSpan => CompactCards ? 1 : 2;
+    public VerticalAlignment NowPlayingTitleVAlign => CompactCards ? VerticalAlignment.Center : VerticalAlignment.Bottom;
+
+    /// <summary>Margin of the now-playing seek slider. The WinUI thumb renders ~6px below the control's
+    /// centre, so when the slider centres in the slim compact host the thumb hangs below and clips; a
+    /// negative top margin lifts the (overflow-centred) slider so the thumb lands at the host centre
+    /// (shift = (top-bottom)/2). Roomy keeps its original bottom-aligned nudge.</summary>
+    public Thickness NowPlayingSeekMargin => CompactCards ? new Thickness(0, -12, 0, 0) : new Thickness(0, 2, 0, -4);
+
+    /// <summary>Height of the seek slider's host in compact. The Slider template's 32px min body (mostly
+    /// empty around the thin track) padded out the strip's bottom; compact drops the host to 16 and lets
+    /// the slider overflow it centred (the host doesn't clip), so only the track + 14px thumb show and the
+    /// row is 16 tall. NaN (Auto) in the roomy layout so the host fits the slider and normal is unchanged.</summary>
+    public double NowPlayingSeekHostHeight => CompactCards ? 16 : double.NaN;
+
+    /// <summary>Top gap above the compact seek host so the slim seek bar isn't crammed against the
+    /// title/artist above it. Zero in the roomy layout (the slider's own margin spaces it there).</summary>
+    public Thickness NowPlayingSeekHostMargin => CompactCards ? new Thickness(0, 6, 0, 0) : new Thickness(0);
+
+    /// <summary>Seek slider alignment within its host: centred in compact (so the thumb sits in the middle
+    /// of the slim 16px host, not clipped), bottom-aligned in the roomy layout (unchanged).</summary>
+    public VerticalAlignment NowPlayingSeekVAlign => CompactCards ? VerticalAlignment.Center : VerticalAlignment.Bottom;
+
     partial void OnCompactCardsChanged(bool value)
     {
         OnPropertyChanged(nameof(NowPlayingStripPadding));
         OnPropertyChanged(nameof(RuleChipPadding));
         OnPropertyChanged(nameof(RuleChipSpacing));
         OnPropertyChanged(nameof(ColumnMinWidth));
+        OnPropertyChanged(nameof(NowPlayingTitleMargin));
+        OnPropertyChanged(nameof(NowPlayingPlaySize));
+        OnPropertyChanged(nameof(NowPlayingPlayCorner));
+        OnPropertyChanged(nameof(NowPlayingPlayGlyph));
+        OnPropertyChanged(nameof(NowPlayingSkipSize));
+        OnPropertyChanged(nameof(NowPlayingSkipCorner));
+        OnPropertyChanged(nameof(NowPlayingSkipGlyph));
+        OnPropertyChanged(nameof(NowPlayingControlsRow));
+        OnPropertyChanged(nameof(NowPlayingControlsRowSpan));
+        OnPropertyChanged(nameof(NowPlayingTitleVAlign));
+        OnPropertyChanged(nameof(NowPlayingSeekMargin));
+        OnPropertyChanged(nameof(NowPlayingSeekHostHeight));
+        OnPropertyChanged(nameof(NowPlayingSeekHostMargin));
+        OnPropertyChanged(nameof(NowPlayingSeekVAlign));
+        // Card-shell geometry.
+        OnPropertyChanged(nameof(CardContentPadding));
+        OnPropertyChanged(nameof(CardSectionSpacing));
+        OnPropertyChanged(nameof(IconTileSize));
+        OnPropertyChanged(nameof(IconGlyphSize));
+        OnPropertyChanged(nameof(WaveLinkIconSize));
+        OnPropertyChanged(nameof(SectionDividerMargin));
+        OnPropertyChanged(nameof(EdgeBleedMargin));
+        OnPropertyChanged(nameof(VolumeRowHeight));
+        OnPropertyChanged(nameof(MeterTotalHeight));
+        OnPropertyChanged(nameof(VolumeSliderMargin));
+        OnPropertyChanged(nameof(ShowRulesCaption));
     }
 
     /// <summary>Whether device cards show their rules section at all. Default on.</summary>

--- a/src/Earmark.App/ViewModels/PeakMeterOptions.cs
+++ b/src/Earmark.App/ViewModels/PeakMeterOptions.cs
@@ -55,9 +55,53 @@ public partial class PeakMeterOptions : ObservableObject
     [ObservableProperty]
     public partial bool ShowCardDividers { get; set; } = true;
 
+    /// <summary>Whether device cards render in the denser compact layout. Default off.
+    /// Shared/observable so toggling the setting re-tightens every card's padding/spacing live
+    /// (each card's layout properties re-raise via <see cref="DeviceCard.NotifyMeterStyleChanged"/>).</summary>
+    [ObservableProperty]
+    public partial bool CompactCards { get; set; }
+
+    /// <summary>Inner padding of each now-playing strip in the current density. The strip band bleeds to
+    /// the card edge, so the horizontal inset re-aligns its content to the card padding (16 roomy / 10
+    /// compact). Bound from the strip template's own scope; re-raised when <see cref="CompactCards"/>
+    /// flips, since the shared options instance (not the per-card properties) backs the strip template.</summary>
+    public Thickness NowPlayingStripPadding => CompactCards ? new Thickness(10, 8, 10, 4) : new Thickness(16, 12, 16, 6);
+
+    /// <summary>Padding inside a rule summary chip. 12,10 roomy / 8,6 compact. Lives here (not just on
+    /// the card) so the expanded additional-rules chips - whose template is RuleSummary-scoped - can
+    /// bind it via the stamped <see cref="RuleSummary.Options"/> and update live with the toggle.</summary>
+    public Thickness RuleChipPadding => CompactCards ? new Thickness(8, 6, 8, 6) : new Thickness(12, 10, 12, 10);
+
+    /// <summary>Spacing between a rule chip's name and status lines. 2 roomy / 1 compact.</summary>
+    public double RuleChipSpacing => CompactCards ? 1 : 2;
+
+    /// <summary>Minimum width of a device-card column in the wrap layouts (the <c>MinItemWidth</c> both
+    /// <see cref="Controls.BlockWrapLayout"/> and the group-members <see cref="Controls.WrapByRowLayout"/>
+    /// consume). Compact packs ~20% tighter (256 vs 320) so more cards fit per row and the window can
+    /// shrink further. Shared/observable so the toggle re-flows the grid live.</summary>
+    public double ColumnMinWidth => CompactCards ? CompactColumnMinWidth : DefaultColumnMinWidth;
+
+    /// <summary>Roomy / compact card-column minimum widths. The window's minimum width is derived from
+    /// the active one (+ the Devices page side padding) in <c>WindowChromeManager</c>.</summary>
+    public const double DefaultColumnMinWidth = 320;
+    public const double CompactColumnMinWidth = 256;
+
+    partial void OnCompactCardsChanged(bool value)
+    {
+        OnPropertyChanged(nameof(NowPlayingStripPadding));
+        OnPropertyChanged(nameof(RuleChipPadding));
+        OnPropertyChanged(nameof(RuleChipSpacing));
+        OnPropertyChanged(nameof(ColumnMinWidth));
+    }
+
     /// <summary>Whether device cards show their rules section at all. Default on.</summary>
     [ObservableProperty]
     public partial bool ShowRules { get; set; } = true;
+
+    /// <summary>Whether device cards show the header badge row (flow label + Default / Communications /
+    /// Disconnected pills). Default on; off frees that line.</summary>
+    [ObservableProperty]
+    public partial bool ShowDeviceBadges { get; set; } = true;
 
     /// <summary>Whether device cards show the now-playing strip when an app exposes SMTC media info.
     /// Default on. Shared/observable so toggling the setting shows or hides every card's strip live.</summary>

--- a/src/Earmark.App/ViewModels/SettingsViewModel.cs
+++ b/src/Earmark.App/ViewModels/SettingsViewModel.cs
@@ -74,6 +74,22 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     public partial int QuickControlsDisplayIndex { get; set; }
 
+    // Quick Controls display overrides (win over the Devices page for the overlay).
+    [ObservableProperty]
+    public partial bool QuickControlsShowRules { get; set; }
+
+    [ObservableProperty]
+    public partial bool QuickControlsShowNowPlaying { get; set; }
+
+    [ObservableProperty]
+    public partial bool QuickControlsShowDeviceBadges { get; set; }
+
+    [ObservableProperty]
+    public partial bool QuickControlsShowDividers { get; set; }
+
+    [ObservableProperty]
+    public partial bool QuickControlsCompact { get; set; }
+
     public string QuickControlsHotkeyStatus => _hotkey.IsRegistered
         ? $"Global shortcut: {QuickControlsHotkey}"
         : _hotkey.RegistrationError ?? $"Global shortcut: {QuickControlsHotkey}";
@@ -329,6 +345,11 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             QuickControlsHotkey = _settings.Current.QuickControlsHotkey;
             QuickControlsBackdropIndex = (int)_settings.Current.QuickControlsBackdrop;
             QuickControlsDisplayIndex = (int)_settings.Current.QuickControlsDisplay;
+            QuickControlsShowRules = _settings.Current.QuickControlsShowRules;
+            QuickControlsShowNowPlaying = _settings.Current.QuickControlsShowNowPlaying;
+            QuickControlsShowDeviceBadges = _settings.Current.QuickControlsShowDeviceBadges;
+            QuickControlsShowDividers = _settings.Current.QuickControlsShowDividers;
+            QuickControlsCompact = _settings.Current.QuickControlsCompact;
             VerboseLogging = _settings.Current.VerboseLogging;
             ShowAppIndicators = _settings.Current.ShowAppIndicators;
             ShowAppPeakMeters = _settings.Current.ShowAppPeakMeters;
@@ -379,6 +400,11 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     partial void OnVerboseLoggingChanged(bool value) => Persist(s => s.VerboseLogging = value);
     partial void OnQuickControlsBackdropIndexChanged(int value) => Persist(s => s.QuickControlsBackdrop = (QuickControlsBackdropMode)value);
     partial void OnQuickControlsDisplayIndexChanged(int value) => Persist(s => s.QuickControlsDisplay = (QuickControlsDisplayMode)value);
+    partial void OnQuickControlsShowRulesChanged(bool value) => Persist(s => s.QuickControlsShowRules = value);
+    partial void OnQuickControlsShowNowPlayingChanged(bool value) => Persist(s => s.QuickControlsShowNowPlaying = value);
+    partial void OnQuickControlsShowDeviceBadgesChanged(bool value) => Persist(s => s.QuickControlsShowDeviceBadges = value);
+    partial void OnQuickControlsShowDividersChanged(bool value) => Persist(s => s.QuickControlsShowDividers = value);
+    partial void OnQuickControlsCompactChanged(bool value) => Persist(s => s.QuickControlsCompact = value);
 
     public bool TrySetQuickControlsHotkey(string hotkey)
     {

--- a/src/Earmark.App/ViewModels/SettingsViewModel.cs
+++ b/src/Earmark.App/ViewModels/SettingsViewModel.cs
@@ -111,9 +111,22 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     public partial int CardHeightModeIndex { get; set; }
 
+    /// <summary>Whether the title bar shows the app title and subtitle. Default on.</summary>
+    [ObservableProperty]
+    public partial bool ShowTitleBarText { get; set; }
+
     /// <summary>Whether device cards draw hairline separators between their sections. Default on.</summary>
     [ObservableProperty]
     public partial bool ShowCardDividers { get; set; }
+
+    /// <summary>Whether device cards render in the denser compact layout. Default off.</summary>
+    [ObservableProperty]
+    public partial bool CompactCards { get; set; }
+
+    /// <summary>Whether device cards show the header badge row (flow label + Default / Communications /
+    /// Disconnected pills). Default on.</summary>
+    [ObservableProperty]
+    public partial bool ShowDeviceBadges { get; set; }
 
     /// <summary>Whether each device card shows its rules section and no-rules text. Default on.</summary>
     [ObservableProperty]
@@ -323,7 +336,10 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             AlwaysShowPinnedApps = _settings.Current.AlwaysShowPinnedApps;
             AppChipLingerSeconds = _settings.Current.AppChipLingerSeconds;
             CardHeightModeIndex = (int)_settings.Current.CardHeight;
+            ShowTitleBarText = _settings.Current.ShowTitleBarText;
             ShowCardDividers = _settings.Current.ShowCardDividers;
+            CompactCards = _settings.Current.CompactCards;
+            ShowDeviceBadges = _settings.Current.ShowDeviceBadges;
             ShowRules = _settings.Current.ShowRules;
             ShowNowPlaying = _settings.Current.ShowNowPlaying;
             NowPlayingCardBackground = _settings.Current.NowPlayingCardBackground;
@@ -477,7 +493,10 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         Persist(s => s.AppChipLingerSeconds = seconds);
     }
     partial void OnCardHeightModeIndexChanged(int value) => Persist(s => s.CardHeight = (CardHeightMode)value);
+    partial void OnShowTitleBarTextChanged(bool value) => Persist(s => s.ShowTitleBarText = value);
     partial void OnShowCardDividersChanged(bool value) => Persist(s => s.ShowCardDividers = value);
+    partial void OnCompactCardsChanged(bool value) => Persist(s => s.CompactCards = value);
+    partial void OnShowDeviceBadgesChanged(bool value) => Persist(s => s.ShowDeviceBadges = value);
     partial void OnShowRulesChanged(bool value) => Persist(s => s.ShowRules = value);
     partial void OnShowNowPlayingChanged(bool value)
     {

--- a/src/Earmark.App/Views/HomePage.xaml
+++ b/src/Earmark.App/Views/HomePage.xaml
@@ -123,7 +123,7 @@
                                        ElementPrepared="OnBlockElementPrepared"
                                        ItemTemplate="{StaticResource DeviceCardTemplate}">
                             <ItemsRepeater.Layout>
-                                <controls:WrapByRowLayout MinItemWidth="320"
+                                <controls:WrapByRowLayout MinItemWidth="{x:Bind MeterOptions.ColumnMinWidth, Mode=OneWay}"
                                                           ColumnSpacing="{StaticResource SpacingMedium}"
                                                           RowSpacing="{StaticResource SpacingMedium}" />
                             </ItemsRepeater.Layout>
@@ -153,12 +153,20 @@
          the window edge (matching Windows Settings). The header and the scroll *content* carry the
          28px side inset instead, so cards line up under the header while the scrollbar hugs the edge. -->
     <Grid x:Name="DevicesRootGrid" Background="Transparent">
-        <!-- Right-click the page background (not a card) for page options; the floating "..." (top
-             right, auto-hides) holds the same items. Card right-clicks show the card's own menu. -->
+        <!-- One menu, two openers: right-click the page background shows it as the context flyout; the
+             floating "..." (top right, auto-hides) calls ShowAt on this same instance, so the items live
+             in one place. Card right-clicks show the card's own menu. Grouped into the per-card display
+             options and the whole-page options. -->
         <Grid.ContextFlyout>
-            <MenuFlyout>
-                <ToggleMenuFlyoutItem Text="Show title bar" IsChecked="{x:Bind ViewModel.ShowDevicesHeader, Mode=TwoWay}" />
+            <MenuFlyout x:Name="DevicesOptionsMenu" Closed="OnOptionsMenuClosed">
+                <MenuFlyoutItem Text="Device card" IsEnabled="False" />
                 <ToggleMenuFlyoutItem Text="Show rules" IsChecked="{x:Bind ViewModel.ShowRules, Mode=TwoWay}" />
+                <ToggleMenuFlyoutItem Text="Card dividers" IsChecked="{x:Bind ViewModel.ShowCardDividers, Mode=TwoWay}" />
+                <ToggleMenuFlyoutItem Text="Device badges" IsChecked="{x:Bind ViewModel.ShowDeviceBadges, Mode=TwoWay}" />
+                <ToggleMenuFlyoutItem Text="Compact cards" IsChecked="{x:Bind ViewModel.CompactCards, Mode=TwoWay}" />
+                <MenuFlyoutSeparator />
+                <MenuFlyoutItem Text="Device page" IsEnabled="False" />
+                <ToggleMenuFlyoutItem Text="Show title bar" IsChecked="{x:Bind ViewModel.ShowDevicesHeader, Mode=TwoWay}" />
                 <ToggleMenuFlyoutItem Text="Show hidden devices" IsChecked="{x:Bind ViewModel.ShowHiddenDevices, Mode=TwoWay}" />
                 <ToggleMenuFlyoutItem Text="Show disconnected devices" IsChecked="{x:Bind ViewModel.ShowDisconnectedDevices, Mode=TwoWay}" />
                 <ToggleMenuFlyoutItem Text="Lock layout" IsChecked="{x:Bind ViewModel.LockLayout, Mode=TwoWay}" />
@@ -261,7 +269,7 @@
                                        Margin="{StaticResource DevicesListBottomMargin}"
                                        VerticalAlignment="Top">
                             <ItemsRepeater.Layout>
-                                <controls:BlockWrapLayout MinItemWidth="320"
+                                <controls:BlockWrapLayout MinItemWidth="{x:Bind ViewModel.MeterOptions.ColumnMinWidth, Mode=OneWay}"
                                                           ColumnSpacing="{StaticResource SpacingMedium}"
                                                           RowSpacing="{StaticResource SpacingMedium}" />
                             </ItemsRepeater.Layout>
@@ -289,18 +297,10 @@
                 CornerRadius="{ThemeResource ControlCornerRadius}"
                 Background="{ThemeResource SubtleFillColorSecondaryBrush}"
                 ToolTipService.ToolTip="Page options"
+                Click="OnOverflowClick"
                 GotFocus="OnOverflowFocusChanged"
                 LostFocus="OnOverflowFocusChanged">
             <FontIcon Glyph="&#xE712;" FontSize="16" />
-            <Button.Flyout>
-                <MenuFlyout Opening="OnOverflowFlyoutOpening" Closed="OnOverflowFlyoutClosed">
-                    <ToggleMenuFlyoutItem Text="Show title bar" IsChecked="{x:Bind ViewModel.ShowDevicesHeader, Mode=TwoWay}" />
-                    <ToggleMenuFlyoutItem Text="Show rules" IsChecked="{x:Bind ViewModel.ShowRules, Mode=TwoWay}" />
-                    <ToggleMenuFlyoutItem Text="Show hidden devices" IsChecked="{x:Bind ViewModel.ShowHiddenDevices, Mode=TwoWay}" />
-                    <ToggleMenuFlyoutItem Text="Show disconnected devices" IsChecked="{x:Bind ViewModel.ShowDisconnectedDevices, Mode=TwoWay}" />
-                    <ToggleMenuFlyoutItem Text="Lock layout" IsChecked="{x:Bind ViewModel.LockLayout, Mode=TwoWay}" />
-                </MenuFlyout>
-            </Button.Flyout>
         </Button>
     </Grid>
 </Page>

--- a/src/Earmark.App/Views/HomePage.xaml.cs
+++ b/src/Earmark.App/Views/HomePage.xaml.cs
@@ -68,13 +68,18 @@ public sealed partial class HomePage : Page
         UpdateOverflowVisibility();
     }
 
-    private void OnOverflowFlyoutOpening(object? sender, object e)
+    // The overflow button shares the page's context-flyout menu (one source of truth) by showing that
+    // same instance at itself. Keep the button pinned visible while its menu is open.
+    private void OnOverflowClick(object sender, RoutedEventArgs e)
     {
         _overflowFlyoutOpen = true;
         UpdateOverflowVisibility();
+        DevicesOptionsMenu.ShowAt(OverflowButton);
     }
 
-    private void OnOverflowFlyoutClosed(object? sender, object e)
+    // Fires for both openers (right-click and the "..." button). Right-click never sets the pinned
+    // flag, so this just clears the button-open case.
+    private void OnOptionsMenuClosed(object? sender, object e)
     {
         _overflowFlyoutOpen = false;
         UpdateOverflowVisibility();
@@ -286,6 +291,7 @@ public sealed partial class HomePage : Page
         var origMeterEnabled = card.MeterEnabledOverride;
         var origPeak = card.ShowPeakIndicatorOverride;
         var origShowRules = card.ShowRulesOverride;
+        var origShowBadges = card.ShowDeviceBadgesOverride;
 
         var pendingNowPlaying = origNowPlaying;
         var pendingFill = origFill;
@@ -294,6 +300,7 @@ public sealed partial class HomePage : Page
         var pendingMeterEnabled = origMeterEnabled;
         var pendingPeak = origPeak;
         var pendingShowRules = origShowRules;
+        var pendingShowBadges = origShowBadges;
 
         var accentBrushRes = (Brush)Application.Current.Resources["AccentFillColorDefaultBrush"];
         var strokeBrushRes = (Brush)Application.Current.Resources["ControlStrokeColorDefaultBrush"];
@@ -357,7 +364,7 @@ public sealed partial class HomePage : Page
         var suppressColour = false;
         // The six override combos, kept for the dependency enable/disable and the reset path.
         ComboBox nowPlayingCombo = null!, fillCombo = null!, appChipsCombo = null!,
-            appMetersCombo = null!, meterCombo = null!, peakCombo = null!, rulesCombo = null!;
+            appMetersCombo = null!, meterCombo = null!, peakCombo = null!, rulesCombo = null!, badgesCombo = null!;
 
         bool IsDirty() =>
             pendingGlyph != origGlyph
@@ -370,13 +377,15 @@ public sealed partial class HomePage : Page
             || pendingAppMeters != origAppMeters
             || pendingMeterEnabled != origMeterEnabled
             || pendingPeak != origPeak
-            || pendingShowRules != origShowRules;
+            || pendingShowRules != origShowRules
+            || pendingShowBadges != origShowBadges;
 
         // "Reset to default" only does something when the pending state isn't already fully default.
         bool PendingIsDefault() =>
             pendingGlyph is null && pendingAccent is null && !pendingNone && !pendingVolumeHidden
             && pendingNowPlaying is null && pendingFill is null && pendingAppChips is null
-            && pendingAppMeters is null && pendingMeterEnabled is null && pendingPeak is null && pendingShowRules is null;
+            && pendingAppMeters is null && pendingMeterEnabled is null && pendingPeak is null && pendingShowRules is null
+            && pendingShowBadges is null;
 
         void RefreshAll()
         {
@@ -533,6 +542,7 @@ public sealed partial class HomePage : Page
         meterCombo = MakeOverrideCombo(card.GlobalMeterEnabled, pendingMeterEnabled, v => pendingMeterEnabled = v);
         peakCombo = MakeOverrideCombo(card.GlobalShowPeakIndicator, pendingPeak, v => pendingPeak = v);
         rulesCombo = MakeOverrideCombo(card.GlobalShowRules, pendingShowRules, v => pendingShowRules = v);
+        badgesCombo = MakeOverrideCombo(card.GlobalShowDeviceBadges, pendingShowBadges, v => pendingShowBadges = v);
 
         // Sub-grouped to mirror the Settings page (and make the child relationships - fill under
         // now-playing, metering under chips - read at a glance). Captions are cheap; the whole
@@ -556,12 +566,14 @@ public sealed partial class HomePage : Page
         AddOverrideRow("Peak indicator", peakCombo, isChild: true);
         AddOverrideCaption("Rules");
         AddOverrideRow("Show rules section", rulesCombo);
+        AddOverrideCaption("Header");
+        AddOverrideRow("Device badges", badgesCombo);
 
         // Auto-expand when the device already deviates from defaults on any axis in this section
         // (including the volume-slider toggle), so an existing customisation is immediately visible.
         var hasAnyOverride = origNowPlaying is not null || origFill is not null || origAppChips is not null
             || origAppMeters is not null || origMeterEnabled is not null || origPeak is not null
-            || origShowRules is not null || origVolumeHidden;
+            || origShowRules is not null || origShowBadges is not null || origVolumeHidden;
         root.Children.Add(new Border
         {
             Height = 1,
@@ -633,7 +645,7 @@ public sealed partial class HomePage : Page
             // Apply the overrides persist-free; SetUserCustomisation's callback then persists every
             // axis (UpdateDeviceConfig reads them all off the card) and reconciles the apps rows.
             card.ApplyFeatureOverrides(pendingNowPlaying, pendingFill, pendingAppChips,
-                pendingAppMeters, pendingMeterEnabled, pendingPeak, pendingShowRules);
+                pendingAppMeters, pendingMeterEnabled, pendingPeak, pendingShowRules, pendingShowBadges);
             card.SetUserCustomisation(pendingGlyph, pendingAccent, pendingNone);
             dialog.Hide();
         };
@@ -646,7 +658,7 @@ public sealed partial class HomePage : Page
             pendingVolumeHidden = false;
             volumeCombo.SelectedIndex = 0; // Show
             // Back to "follow global" on every override (index 0 fires each combo's change handler).
-            pendingNowPlaying = pendingFill = pendingAppChips = pendingAppMeters = pendingMeterEnabled = pendingPeak = pendingShowRules = null;
+            pendingNowPlaying = pendingFill = pendingAppChips = pendingAppMeters = pendingMeterEnabled = pendingPeak = pendingShowRules = pendingShowBadges = null;
             nowPlayingCombo.SelectedIndex = 0;
             fillCombo.SelectedIndex = 0;
             appChipsCombo.SelectedIndex = 0;
@@ -654,6 +666,7 @@ public sealed partial class HomePage : Page
             meterCombo.SelectedIndex = 0;
             peakCombo.SelectedIndex = 0;
             rulesCombo.SelectedIndex = 0;
+            badgesCombo.SelectedIndex = 0;
             SeedColour();
             RefreshAll();
         };

--- a/src/Earmark.App/Views/QuickControlsWindow.xaml
+++ b/src/Earmark.App/Views/QuickControlsWindow.xaml
@@ -37,7 +37,7 @@
                 <Border Style="{StaticResource SectionCardStyle}"
                         Padding="0"
                         Opacity="{x:Bind CardOpacity, Mode=OneWay}">
-                    <controls:DeviceCardView Card="{x:Bind}" ShowRules="False" AllowContextMenu="False" />
+                    <controls:DeviceCardView Card="{x:Bind}" Options="{x:Bind QuickMeterOptions, Mode=OneWay}" AllowContextMenu="False" QuickControlsMenu="True" />
                 </Border>
             </DataTemplate>
 
@@ -47,6 +47,15 @@
                  extent (phantom whitespace + a stray recycled card) past the real content. -->
             <DataTemplate x:Key="QuickGroupTemplate" x:DataType="vm:DeviceGroupCard">
                 <StackPanel Spacing="8">
+                    <StackPanel.ContextFlyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem Text="Settings" Click="OnQuickControlsSettingsClicked">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE713;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyout>
+                    </StackPanel.ContextFlyout>
                     <TextBlock Text="{x:Bind Title, Mode=OneWay}"
                                Margin="2,0,0,0"
                                FontWeight="SemiBold"

--- a/src/Earmark.App/Views/QuickControlsWindow.xaml.cs
+++ b/src/Earmark.App/Views/QuickControlsWindow.xaml.cs
@@ -126,6 +126,11 @@ public sealed partial class QuickControlsWindow : Window
         return height;
     }
 
+    // The group title's "Settings" context-menu item (member cards route their own copy through
+    // DeviceCardView). Mirrors the card item: jump to the Quick Controls settings in the main window.
+    private void OnQuickControlsSettingsClicked(object sender, RoutedEventArgs e) =>
+        App.Current.OpenQuickControlsSettings();
+
     public void ShowPrepared(bool animate = true)
     {
         if (animate)

--- a/src/Earmark.App/Views/SettingsPage.xaml
+++ b/src/Earmark.App/Views/SettingsPage.xaml
@@ -100,6 +100,13 @@
                         <ComboBoxItem Content="Solid" />
                     </ComboBox>
                 </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Title bar text"
+                                   Description="Show the &quot;Earmark&quot; title and &quot;Audio rules engine&quot; subtitle in the title bar. Off leaves just the app icon and window buttons. The subtitle hides on its own when the window is too narrow to fit it.">
+                    <ctrl:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE7C4;" />
+                    </ctrl:SettingsCard.HeaderIcon>
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.ShowTitleBarText, Mode=TwoWay}" />
+                </ctrl:SettingsCard>
 
                 <TextBlock Text="Devices" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,0" />
                 <ctrl:SettingsCard Header="Card height"
@@ -113,12 +120,26 @@
                         <ComboBoxItem Content="Dynamic" />
                     </ComboBox>
                 </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Compact cards"
+                                   Description="Denser device cards: tighter padding and spacing, a smaller icon tile, and trimmed now-playing strips. Applies to the Devices page and Quick Controls.">
+                    <ctrl:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE71F;" />
+                    </ctrl:SettingsCard.HeaderIcon>
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.CompactCards, Mode=TwoWay}" />
+                </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Card dividers"
                                    Description="Draw a thin separator line between each card's sections (volume, rules, apps), stacking them like a Windows Settings card. Off keeps the sections separated by spacing alone.">
                     <ctrl:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE8A1;" />
                     </ctrl:SettingsCard.HeaderIcon>
                     <ToggleSwitch IsOn="{x:Bind ViewModel.ShowCardDividers, Mode=TwoWay}" />
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Device badges"
+                                   Description="Show the Input / Output flow label and the Default / Communications / Disconnected pills on each card. Off hides that row and frees the space. Override per device in Customise.">
+                    <ctrl:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE8EC;" />
+                    </ctrl:SettingsCard.HeaderIcon>
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.ShowDeviceBadges, Mode=TwoWay}" />
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Show rules"
                                    Description="Show each device card's rules section. Off hides the entire rules section on every card.">
@@ -400,6 +421,13 @@
                     <ctrl:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE946;" />
                     </ctrl:SettingsCard.HeaderIcon>
+                </ctrl:SettingsCard>
+                <ctrl:SettingsCard Header="Support Earmark"
+                                   Description="Earmark is free and open source. If it's useful to you, a donation helps keep it maintained.">
+                    <ctrl:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xEB51;" />
+                    </ctrl:SettingsCard.HeaderIcon>
+                    <HyperlinkButton Content="Donate" Click="OnDonate" />
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Check for updates"
                                    Description="{x:Bind About.UpdateStatusText, Mode=OneWay}"

--- a/src/Earmark.App/Views/SettingsPage.xaml
+++ b/src/Earmark.App/Views/SettingsPage.xaml
@@ -51,9 +51,10 @@
                     <ToggleSwitch IsOn="{x:Bind ViewModel.LaunchOnStartup, Mode=TwoWay}" />
                 </ctrl:SettingsCard>
 
-                <ctrl:SettingsExpander Header="Quick Controls"
+                <ctrl:SettingsExpander x:Name="QuickControlsExpander"
+                                       Header="Quick Controls"
                                        Description="A floating device-control overlay for pinned devices and groups."
-                                       IsExpanded="{x:Bind ViewModel.QuickControlsEnabled, Mode=OneWay}">
+                                       IsExpanded="False">
                     <ctrl:SettingsExpander.HeaderIcon>
                         <FontIcon Glyph="&#xE718;" />
                     </ctrl:SettingsExpander.HeaderIcon>
@@ -82,11 +83,34 @@
                                 <ComboBoxItem Content="Default display" />
                             </ComboBox>
                         </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Compact layout"
+                                           Description="Render Quick Controls cards in the compact layout, independent of the Devices page.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.QuickControlsCompact, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Show now playing"
+                                           Description="Show the now-playing strip on Quick Controls cards.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.QuickControlsShowNowPlaying, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Show device badges"
+                                           Description="Show the Input / Output and Default / Communications pills on Quick Controls cards.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.QuickControlsShowDeviceBadges, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Show dividers"
+                                           Description="Draw the hairline section dividers on Quick Controls cards.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.QuickControlsShowDividers, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Show rules"
+                                           Description="Show each card's rules section in Quick Controls. Off keeps the overlay focused on volume and now-playing.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.QuickControlsShowRules, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
                     </ctrl:SettingsExpander.Items>
                 </ctrl:SettingsExpander>
 
                 <TextBlock Text="Appearance" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,0" />
                 <ctrl:SettingsCard Header="Theme" Description="Choose a light or dark appearance, or follow the Windows setting.">
+                    <ctrl:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE771;" />
+                    </ctrl:SettingsCard.HeaderIcon>
                     <ComboBox SelectedIndex="{x:Bind ViewModel.AppThemeIndex, Mode=TwoWay}" MinWidth="140">
                         <ComboBoxItem Content="System" />
                         <ComboBoxItem Content="Light" />
@@ -94,6 +118,9 @@
                     </ComboBox>
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Backdrop" Description="The window's background material. Mica tints the desktop wallpaper, Acrylic blurs whatever sits behind the window, and Solid is an opaque themed surface.">
+                    <ctrl:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE81E;" />
+                    </ctrl:SettingsCard.HeaderIcon>
                     <ComboBox SelectedIndex="{x:Bind ViewModel.BackdropIndex, Mode=TwoWay}" MinWidth="140">
                         <ComboBoxItem Content="Mica" />
                         <ComboBoxItem Content="Acrylic" />
@@ -109,46 +136,41 @@
                 </ctrl:SettingsCard>
 
                 <TextBlock Text="Devices" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,0" />
-                <ctrl:SettingsCard Header="Card height"
-                                   Description="How tall device cards are within a row. Balanced matches every card in a row to the tallest, cards playing apps included, but lets a card with its rules expanded keep its own height; Match row matches every card, expanded ones included; Dynamic sizes each card to its own content.">
-                    <ctrl:SettingsCard.HeaderIcon>
+                <ctrl:SettingsExpander Header="Device card appearance"
+                                       Description="Height, density, dividers, badges, and which sections show on each device card."
+                                       IsExpanded="False">
+                    <ctrl:SettingsExpander.HeaderIcon>
                         <FontIcon Glyph="&#xE8A9;" />
-                    </ctrl:SettingsCard.HeaderIcon>
-                    <ComboBox SelectedIndex="{x:Bind ViewModel.CardHeightModeIndex, Mode=TwoWay}" MinWidth="150">
-                        <ComboBoxItem Content="Balanced" />
-                        <ComboBoxItem Content="Match row" />
-                        <ComboBoxItem Content="Dynamic" />
-                    </ComboBox>
-                </ctrl:SettingsCard>
-                <ctrl:SettingsCard Header="Compact cards"
-                                   Description="Denser device cards: tighter padding and spacing, a smaller icon tile, and trimmed now-playing strips. Applies to the Devices page and Quick Controls.">
-                    <ctrl:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE71F;" />
-                    </ctrl:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.CompactCards, Mode=TwoWay}" />
-                </ctrl:SettingsCard>
-                <ctrl:SettingsCard Header="Card dividers"
-                                   Description="Draw a thin separator line between each card's sections (volume, rules, apps), stacking them like a Windows Settings card. Off keeps the sections separated by spacing alone.">
-                    <ctrl:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE8A1;" />
-                    </ctrl:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.ShowCardDividers, Mode=TwoWay}" />
-                </ctrl:SettingsCard>
-                <ctrl:SettingsCard Header="Device badges"
-                                   Description="Show the Input / Output flow label and the Default / Communications / Disconnected pills on each card. Off hides that row and frees the space. Override per device in Customise.">
-                    <ctrl:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE8EC;" />
-                    </ctrl:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.ShowDeviceBadges, Mode=TwoWay}" />
-                </ctrl:SettingsCard>
-                <ctrl:SettingsCard Header="Show rules"
-                                   Description="Show each device card's rules section. Off hides the entire rules section on every card.">
-                    <ctrl:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE8A5;" />
-                    </ctrl:SettingsCard.HeaderIcon>
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRules, Mode=TwoWay}" />
-                </ctrl:SettingsCard>
+                    </ctrl:SettingsExpander.HeaderIcon>
+                    <ctrl:SettingsExpander.Items>
+                        <ctrl:SettingsCard Header="Card height"
+                                           Description="How tall device cards are within a row. Balanced matches every card in a row to the tallest, cards playing apps included, but lets a card with its rules expanded keep its own height; Match row matches every card, expanded ones included; Dynamic sizes each card to its own content.">
+                            <ComboBox SelectedIndex="{x:Bind ViewModel.CardHeightModeIndex, Mode=TwoWay}" MinWidth="150">
+                                <ComboBoxItem Content="Balanced" />
+                                <ComboBoxItem Content="Match row" />
+                                <ComboBoxItem Content="Dynamic" />
+                            </ComboBox>
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Compact cards"
+                                           Description="Denser device cards: tighter padding and spacing, a smaller icon tile, and trimmed now-playing strips. Applies to the Devices page and Quick Controls.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.CompactCards, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Card dividers"
+                                           Description="Draw a thin separator line between each card's sections (volume, rules, apps), stacking them like a Windows Settings card. Off keeps the sections separated by spacing alone.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowCardDividers, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Device badges"
+                                           Description="Show the Input / Output flow label and the Default / Communications / Disconnected pills on each card. Off hides that row and frees the space. Override per device in Customise.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowDeviceBadges, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
+                        <ctrl:SettingsCard Header="Show rules"
+                                           Description="Show each device card's rules section. Off hides the entire rules section on every card.">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.ShowRules, Mode=TwoWay}" />
+                        </ctrl:SettingsCard>
+                    </ctrl:SettingsExpander.Items>
+                </ctrl:SettingsExpander>
                 <InfoBar IsOpen="{x:Bind ViewModel.HasRulesOverrides, Mode=OneWay}" IsClosable="False"
+                         Visibility="{x:Bind ViewModel.HasRulesOverrides, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                          Severity="Informational" Margin="0,4,0,0"
                          Message="{x:Bind ViewModel.RulesOverrideMessage, Mode=OneWay}"
                          ToolTipService.ToolTip="{x:Bind ViewModel.RulesOverrideTooltip, Mode=OneWay}">
@@ -158,7 +180,7 @@
                 </InfoBar>
                 <ctrl:SettingsExpander Header="App indicators"
                                        Description="Show a chip for each app playing through a device, on that device's card. Drag a chip onto another card to reroute the app."
-                                       IsExpanded="{x:Bind ViewModel.ShowAppIndicators, Mode=OneWay}">
+                                       IsExpanded="False">
                     <ctrl:SettingsExpander.HeaderIcon>
                         <FontIcon Glyph="&#xE71D;" />
                     </ctrl:SettingsExpander.HeaderIcon>
@@ -199,6 +221,7 @@
                     </ctrl:SettingsExpander.Items>
                 </ctrl:SettingsExpander>
                 <InfoBar IsOpen="{x:Bind ViewModel.HasAppIndicatorsOverrides, Mode=OneWay}" IsClosable="False"
+                         Visibility="{x:Bind ViewModel.HasAppIndicatorsOverrides, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                          Severity="Informational" Margin="0,4,0,0"
                          Message="{x:Bind ViewModel.AppIndicatorsOverrideMessage, Mode=OneWay}"
                          ToolTipService.ToolTip="{x:Bind ViewModel.AppIndicatorsOverrideTooltip, Mode=OneWay}">
@@ -207,6 +230,7 @@
                     </InfoBar.ActionButton>
                 </InfoBar>
                 <InfoBar IsOpen="{x:Bind ViewModel.HasAppMetersOverrides, Mode=OneWay}" IsClosable="False"
+                         Visibility="{x:Bind ViewModel.HasAppMetersOverrides, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                          Severity="Informational" Margin="0,4,0,0"
                          Title="Volume meters"
                          Message="{x:Bind ViewModel.AppMetersOverrideMessage, Mode=OneWay}"
@@ -218,7 +242,7 @@
 
                 <ctrl:SettingsExpander Header="Now playing"
                                        Description="Show a media strip on a device's card when an app playing through it exposes track info (title, artwork, transport controls) to Windows. The app's chip moves into the strip."
-                                       IsExpanded="{x:Bind ViewModel.ShowNowPlaying, Mode=OneWay}">
+                                       IsExpanded="False">
                     <ctrl:SettingsExpander.HeaderIcon>
                         <FontIcon Glyph="&#xE768;" />
                     </ctrl:SettingsExpander.HeaderIcon>
@@ -232,6 +256,7 @@
                     </ctrl:SettingsExpander.Items>
                 </ctrl:SettingsExpander>
                 <InfoBar IsOpen="{x:Bind ViewModel.HasNowPlayingOverrides, Mode=OneWay}" IsClosable="False"
+                         Visibility="{x:Bind ViewModel.HasNowPlayingOverrides, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                          Severity="Informational" Margin="0,4,0,0"
                          Message="{x:Bind ViewModel.NowPlayingOverrideMessage, Mode=OneWay}"
                          ToolTipService.ToolTip="{x:Bind ViewModel.NowPlayingOverrideTooltip, Mode=OneWay}">
@@ -240,6 +265,7 @@
                     </InfoBar.ActionButton>
                 </InfoBar>
                 <InfoBar IsOpen="{x:Bind ViewModel.HasNowPlayingFillOverrides, Mode=OneWay}" IsClosable="False"
+                         Visibility="{x:Bind ViewModel.HasNowPlayingFillOverrides, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                          Severity="Informational" Margin="0,4,0,0"
                          Title="Fill card background"
                          Message="{x:Bind ViewModel.NowPlayingFillOverrideMessage, Mode=OneWay}"
@@ -251,6 +277,9 @@
 
                 <ctrl:SettingsExpander Header="Peak meter"
                                        Description="The level meter behind each device's volume slider. Off hides it and shows a plain slider.">
+                    <ctrl:SettingsExpander.HeaderIcon>
+                        <FontIcon Glyph="&#xE9E9;" />
+                    </ctrl:SettingsExpander.HeaderIcon>
                     <ComboBox SelectedIndex="{x:Bind ViewModel.PeakMeterColourModeIndex, Mode=TwoWay}" MinWidth="150">
                         <ComboBoxItem Content="Gradient" />
                         <ComboBoxItem Content="Blocks" />
@@ -298,6 +327,7 @@
                     </ctrl:SettingsExpander.Items>
                 </ctrl:SettingsExpander>
                 <InfoBar IsOpen="{x:Bind ViewModel.HasMeterEnabledOverrides, Mode=OneWay}" IsClosable="False"
+                         Visibility="{x:Bind ViewModel.HasMeterEnabledOverrides, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                          Severity="Informational" Margin="0,4,0,0"
                          Title="Peak meter"
                          Message="{x:Bind ViewModel.MeterEnabledOverrideMessage, Mode=OneWay}"
@@ -307,6 +337,7 @@
                     </InfoBar.ActionButton>
                 </InfoBar>
                 <InfoBar IsOpen="{x:Bind ViewModel.HasPeakIndicatorOverrides, Mode=OneWay}" IsClosable="False"
+                         Visibility="{x:Bind ViewModel.HasPeakIndicatorOverrides, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                          Severity="Informational" Margin="0,4,0,0"
                          Title="Peak-hold tick"
                          Message="{x:Bind ViewModel.PeakIndicatorOverrideMessage, Mode=OneWay}"
@@ -327,7 +358,10 @@
                 <TextBlock Text="System tray" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,0" />
                 <ctrl:SettingsExpander Header="Show tray icon"
                                        Description="Display the Earmark icon in the Windows notification area. The behaviours below need it on."
-                                       IsExpanded="{x:Bind ViewModel.ShowTrayIcon, Mode=OneWay}">
+                                       IsExpanded="False">
+                    <ctrl:SettingsExpander.HeaderIcon>
+                        <FontIcon Glyph="&#xEA8F;" />
+                    </ctrl:SettingsExpander.HeaderIcon>
                     <ToggleSwitch IsOn="{x:Bind ViewModel.ShowTrayIcon, Mode=TwoWay}" />
                     <ctrl:SettingsExpander.Items>
                         <ctrl:SettingsCard Header="Minimize to tray"
@@ -351,7 +385,7 @@
                 <TextBlock Text="Wave Link" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,0" />
                 <ctrl:SettingsExpander Header="Wave Link integration"
                                        Description="Route Wave Link mix outputs from rules. Earmark connects to Wave Link's local WebSocket while the integration is on."
-                                       IsExpanded="{x:Bind ViewModel.EnableWaveLink, Mode=OneWay}">
+                                       IsExpanded="False">
                     <ctrl:SettingsExpander.HeaderIcon>
                         <FontIcon Glyph="&#xE767;" />
                     </ctrl:SettingsExpander.HeaderIcon>
@@ -383,6 +417,9 @@
 
                 <TextBlock Text="Diagnostics" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,16,0,0" />
                 <ctrl:SettingsCard Header="Verbose logging" Description="Write debug-level diagnostics to the log file. Leave off for normal use.">
+                    <ctrl:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE9D9;" />
+                    </ctrl:SettingsCard.HeaderIcon>
                     <ToggleSwitch IsOn="{x:Bind ViewModel.VerboseLogging, Mode=TwoWay}" />
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Logs"
@@ -431,6 +468,7 @@
                 </ctrl:SettingsCard>
                 <ctrl:SettingsCard Header="Check for updates"
                                    Description="{x:Bind About.UpdateStatusText, Mode=OneWay}"
+                                   IsEnabled="{x:Bind About.IsUpdateCheckEnabled}"
                                    Visibility="{x:Bind About.IsUpdateCheckSupported, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <ctrl:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE895;" />

--- a/src/Earmark.App/Views/SettingsPage.xaml.cs
+++ b/src/Earmark.App/Views/SettingsPage.xaml.cs
@@ -38,6 +38,27 @@ public sealed partial class SettingsPage : Page
 
     public AboutViewModel About { get; }
 
+    /// <summary>Expands the Quick Controls settings and scrolls it into view. Invoked when "Settings" is
+    /// chosen from a Quick Controls card's context menu. Deferred to the dispatcher (and the Loaded event
+    /// when the singleton page is off-screen) so it runs after the page is shown and laid out.</summary>
+    public void RevealQuickControls()
+    {
+        void Reveal()
+        {
+            QuickControlsExpander.IsExpanded = true;
+            QuickControlsExpander.StartBringIntoView(new BringIntoViewOptions { VerticalAlignmentRatio = 0 });
+        }
+
+        void OnLoadedReveal(object sender, RoutedEventArgs e)
+        {
+            Loaded -= OnLoadedReveal;
+            DispatcherQueue.TryEnqueue(Reveal);
+        }
+
+        if (IsLoaded) DispatcherQueue.TryEnqueue(Reveal);
+        else Loaded += OnLoadedReveal;
+    }
+
     private void OnMeterPickerColourChanged(DependencyObject sender, DependencyProperty dp)
     {
         if (_syncingMeterColour || MeterColourPicker.SelectedColour is not Color colour) return;

--- a/src/Earmark.App/Views/SettingsPage.xaml.cs
+++ b/src/Earmark.App/Views/SettingsPage.xaml.cs
@@ -83,6 +83,8 @@ public sealed partial class SettingsPage : Page
 
     private void OnOpenGitHub(object sender, RoutedEventArgs e) => About.OpenGitHub();
 
+    private void OnDonate(object sender, RoutedEventArgs e) => About.Donate();
+
     private void OnOpenLogsFolder(object sender, RoutedEventArgs e) => About.OpenLogsFolder();
 
     private async void OnManageHiddenApps(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Compact card density plus a Quick Controls overlay that is now its own configurable view, independent of the Devices page.

## Compact cards
Denser device cards (tighter padding and spacing, a smaller icon tile, a trimmed now-playing strip), toggled globally from Settings or the Devices backdrop menu. The roomy layout is untouched: every compact value falls back to the original when the mode is off.

## Quick Controls as its own view
Card display is resolved per window through a `CardPresentation` projection over the shared card and strip instances, so the overlay and the main window can differ in density and features without duplicating live state. Quick Controls carries its own overrides (rules off, now-playing on, badges off, dividers off, compact on by default). Right-clicking a card or a group title offers a single "Settings" item that restores the main window and reveals the Quick Controls section.

## Settings page
Device-card settings are grouped under a "Device card appearance" expander, every section is collapsed on launch, header icons were added, and closed override info bars now collapse out of layout so card spacing is even. The update-check card is disabled as a whole on Dev builds. Device badges (the flow / Default / Communications pills) are hideable globally and per device.

---

feat: compact card density mode for the Devices page and Quick Controls

feat: hideable device badges, globally and per device

feat: Quick Controls as a configurable view with its own rules, now-playing, badge, divider, and compact overrides

feat: a Settings context menu on Quick Controls cards and group titles

fix: disable the whole update-check card on Dev builds, not just the button

fix: even out Devices settings spacing by collapsing closed override info bars out of layout
