### PR TITLE
fix: smooth now-playing seek bar

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -33,10 +33,19 @@ body:
       required: false
 
   - type: textarea
+    id: mockup
+    attributes:
+      label: Mockup
+      description: If your idea is visual, drag in a mockup, sketch, or annotated screenshot of how the option could look.
+      placeholder: "Drag an image here to attach it."
+    validations:
+      required: false
+
+  - type: textarea
     id: context
     attributes:
       label: Additional Context
-      description: Screenshots, mockups, links to related issues, audio device specifics, or anything else that helps explain the request.
+      description: Links to related issues, audio device specifics, or anything else that helps explain the request.
     validations:
       required: false
 

--- a/src/Earmark.App/Controls/DeviceCardView.xaml
+++ b/src/Earmark.App/Controls/DeviceCardView.xaml
@@ -557,11 +557,14 @@
                                             </Button>
                                         </StackPanel>
 
-                                        <!-- Seek bar: a real Slider (draggable thumb). Value is the
-                                             position in seconds (Maximum = duration) so the thumb tooltip
-                                             shows a timestamp; a drag seeks on release (Esc cancels).
-                                             Pointer handlers are wired in code-behind with handledEventsToo
-                                             so grabbing the thumb still freezes the bar. -->
+                                        <!-- Seek bar (custom; no Slider). The track/fill/thumb ARE the control:
+                                             the fill (ScaleX) and thumb (TranslateX) are positioned by
+                                             RenderTransforms, which are sub-pixel and render-thread, so they glide
+                                             as the 20 Hz position advances. A WinUI Slider can't do this - it
+                                             recomputes its thumb offset via layout and rounds to a whole pixel each
+                                             frame (~1px/second on a narrow card = the visible "jump"). Code-behind
+                                             drives the transforms from the strip position and handles pointer/keyboard
+                                             seeking (drag to scrub, commit on release, Esc cancels). -->
                                         <!-- Seek host: a fixed-height row in compact (16) that the slider
                                              overflows centred (the host doesn't clip), so the row is slim
                                              without the template's 32px body padding out the bottom and
@@ -570,22 +573,50 @@
                                               Height="{x:Bind Options.NowPlayingSeekHostHeight, Mode=OneWay}"
                                               Margin="{x:Bind Options.NowPlayingSeekHostMargin, Mode=OneWay}"
                                               Visibility="{x:Bind Strip.HasProgress, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                            <Slider Minimum="0"
-                                                    Maximum="{x:Bind Strip.DurationSeconds, Mode=OneWay}"
-                                                    StepFrequency="1"
-                                                    Value="{x:Bind Strip.PositionSeconds, Mode=OneWay}"
-                                                    ThumbToolTipValueConverter="{StaticResource SecondsToTimestampConverter}"
-                                                    Margin="{x:Bind Options.NowPlayingSeekMargin, Mode=OneWay}"
-                                                    VerticalAlignment="{x:Bind Options.NowPlayingSeekVAlign, Mode=OneWay}"
-                                                    Tag="{x:Bind Strip}"
-                                                    Loaded="OnSeekSliderLoaded">
-                                                <!-- Default (theme-aware, accessible) slider chrome; thumb
-                                                     sized to match the volume slider for visual consistency. -->
-                                                <Slider.Resources>
-                                                    <x:Double x:Key="SliderHorizontalThumbWidth">14</x:Double>
-                                                    <x:Double x:Key="SliderHorizontalThumbHeight">14</x:Double>
-                                                </Slider.Resources>
-                                            </Slider>
+                                            <Grid Tag="{x:Bind Strip}"
+                                                  Background="Transparent"
+                                                  IsTabStop="True"
+                                                  UseSystemFocusVisuals="True"
+                                                  Margin="{x:Bind Options.NowPlayingSeekMargin, Mode=OneWay}"
+                                                  AutomationProperties.Name="Seek position"
+                                                  Loaded="OnSeekBarLoaded"
+                                                  Unloaded="OnSeekBarUnloaded"
+                                                  SizeChanged="OnSeekBarSizeChanged"
+                                                  PointerPressed="OnSeekBarPointerPressed"
+                                                  PointerMoved="OnSeekBarPointerMoved"
+                                                  PointerReleased="OnSeekBarPointerReleased"
+                                                  PointerCaptureLost="OnSeekBarPointerReleased"
+                                                  KeyDown="OnSeekBarKeyDown"
+                                                  KeyUp="OnSeekBarKeyUp">
+                                                <Border Height="3" CornerRadius="1.5" VerticalAlignment="Center"
+                                                        Background="{ThemeResource ControlStrongFillColorDefaultBrush}" />
+                                                <Border Tag="SeekFill" Height="3" CornerRadius="1.5"
+                                                        HorizontalAlignment="Stretch" VerticalAlignment="Center"
+                                                        RenderTransformOrigin="0,0.5"
+                                                        Background="{ThemeResource AccentFillColorDefaultBrush}">
+                                                    <Border.RenderTransform>
+                                                        <ScaleTransform ScaleX="0" />
+                                                    </Border.RenderTransform>
+                                                </Border>
+                                                <Ellipse Tag="SeekThumb" Width="14" Height="14"
+                                                         HorizontalAlignment="Left" VerticalAlignment="Center"
+                                                         Fill="{ThemeResource AccentFillColorDefaultBrush}">
+                                                    <Ellipse.RenderTransform>
+                                                        <TranslateTransform />
+                                                    </Ellipse.RenderTransform>
+                                                </Ellipse>
+                                                <!-- Drag/keyboard-seek timestamp; a Popup so it floats above
+                                                     the bar without being clipped. Positioned in code to follow
+                                                     the thumb. -->
+                                                <Popup Tag="SeekTip">
+                                                    <Border Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
+                                                            BorderBrush="{ThemeResource SurfaceStrokeColorFlyoutBrush}"
+                                                            BorderThickness="1" CornerRadius="4" Padding="6,1">
+                                                        <TextBlock Tag="SeekTipText" FontSize="12"
+                                                                   Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                                                    </Border>
+                                                </Popup>
+                                            </Grid>
                                         </Grid>
 
                                         <!-- LIVE indicator: shown instead of the seek bar for a live /

--- a/src/Earmark.App/Controls/DeviceCardView.xaml.cs
+++ b/src/Earmark.App/Controls/DeviceCardView.xaml.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 using Earmark.App.ViewModels;
 using Earmark.App.Views;
 
@@ -6,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
@@ -465,49 +468,211 @@ public sealed partial class DeviceCardView : UserControl
         }
     }
 
-    // ---- Now-playing seek slider (freeze position while dragging, seek on release) ----
+    // ---- Now-playing seek bar (custom; track/fill/thumb are RenderTransform-positioned so they glide) ----
 
-    // Grabbing the Slider's Thumb marks the pointer events handled, so plain XAML handlers never fire.
-    // Wiring them with handledEventsToo:true (and on the Thumb's drag, via PointerCaptureLost for the
-    // end) makes the freeze engage whether the user grabs the thumb or clicks the track.
-    private void OnSeekSliderLoaded(object sender, RoutedEventArgs e)
+    // The seek bar is a plain Grid, not a Slider: a Slider positions its thumb via layout and rounds the
+    // offset to a whole pixel each frame, which on a narrow card steps ~once a second. Here the fill (ScaleX)
+    // and thumb (TranslateX) are moved by RenderTransforms - sub-pixel, render-thread - driven from the strip
+    // position at 20 Hz, so they glide. Code-behind also owns the interaction: drag to scrub (freezes the
+    // strip), commit on release, Esc cancels, arrow/page/Home/End nudge.
+    private const double SeekNudgeSeconds = 5;
+    private const double SeekPageSeconds = 15;
+
+    private sealed class SeekBar
     {
-        if (sender is not Slider slider) return;
-        slider.AddHandler(PointerPressedEvent, new PointerEventHandler(OnSeekSliderPressed), handledEventsToo: true);
-        slider.AddHandler(PointerReleasedEvent, new PointerEventHandler(OnSeekSliderReleased), handledEventsToo: true);
-        slider.AddHandler(PointerCaptureLostEvent, new PointerEventHandler(OnSeekSliderReleased), handledEventsToo: true);
-        slider.AddHandler(KeyDownEvent, new KeyEventHandler(OnSeekSliderKeyDown), handledEventsToo: true);
-        slider.AddHandler(KeyUpEvent, new KeyEventHandler(OnSeekSliderKeyUp), handledEventsToo: true);
+        public required Grid Root;
+        public required NowPlayingStrip Strip;
+        public required ScaleTransform Fill;
+        public required TranslateTransform Thumb;
+        public required FrameworkElement ThumbElement;
+        public Popup? Tip;
+        public TextBlock? TipText;
+        public PropertyChangedEventHandler PositionHandler = null!;
+        public bool Seeking;          // pointer drag or keyboard nudge in progress
+        public double PendingSeconds; // position the in-progress seek will commit to
     }
 
-    private void OnSeekSliderPressed(object sender, PointerRoutedEventArgs e)
+    private readonly Dictionary<Grid, SeekBar> _seekBars = new();
+
+    private void OnSeekBarLoaded(object sender, RoutedEventArgs e)
     {
-        if (sender is not Slider { Tag: NowPlayingStrip strip } slider) return;
-        strip.BeginSeek();
-        // Focus the slider so Escape (to cancel the drag) reaches its KeyDown while the pointer is held.
-        slider.Focus(FocusState.Pointer);
+        if (sender is not Grid { Tag: NowPlayingStrip strip } root || _seekBars.ContainsKey(root)) return;
+
+        ScaleTransform? fill = null;
+        TranslateTransform? thumb = null;
+        FrameworkElement? thumbElement = null;
+        Popup? tip = null;
+        foreach (var child in root.Children.OfType<FrameworkElement>())
+        {
+            switch (child.Tag as string)
+            {
+                case "SeekFill": fill = child.RenderTransform as ScaleTransform; break;
+                case "SeekThumb": thumb = child.RenderTransform as TranslateTransform; thumbElement = child; break;
+                case "SeekTip": tip = child as Popup; break;
+            }
+        }
+        if (fill is null || thumb is null || thumbElement is null) return;
+
+        var bar = new SeekBar
+        {
+            Root = root, Strip = strip, Fill = fill, Thumb = thumb, ThumbElement = thumbElement,
+            Tip = tip, TipText = (tip?.Child as Border)?.Child as TextBlock,
+        };
+        bar.PositionHandler = (_, args) =>
+        {
+            if (args.PropertyName is nameof(NowPlayingStrip.PositionSeconds) or nameof(NowPlayingStrip.DurationSeconds))
+                RenderSeekBar(bar);
+        };
+        strip.PropertyChanged += bar.PositionHandler;
+        _seekBars[root] = bar;
+        RenderSeekBar(bar);
     }
 
-    private void OnSeekSliderReleased(object sender, PointerRoutedEventArgs e)
+    private void OnSeekBarUnloaded(object sender, RoutedEventArgs e)
     {
-        if (sender is Slider { Tag: NowPlayingStrip strip } slider) _ = strip.EndSeekAsync(slider.Value);
+        if (sender is Grid root && _seekBars.Remove(root, out var bar))
+            bar.Strip.PropertyChanged -= bar.PositionHandler;
     }
 
-    private void OnSeekSliderKeyDown(object sender, KeyRoutedEventArgs e)
+    private void OnSeekBarSizeChanged(object sender, SizeChangedEventArgs e)
     {
-        if (sender is not Slider { Tag: NowPlayingStrip strip }) return;
+        if (sender is Grid root && _seekBars.TryGetValue(root, out var bar)) RenderSeekBar(bar);
+    }
+
+    // Follows PendingSeconds while a seek is in progress (drag/nudge target), else the strip's live position.
+    private void RenderSeekBar(SeekBar bar)
+    {
+        var duration = bar.Strip.DurationSeconds;
+        var seconds = bar.Seeking ? bar.PendingSeconds : bar.Strip.PositionSeconds;
+        ApplySeekRatio(bar, duration > 0 ? Math.Clamp(seconds / duration, 0, 1) : 0);
+    }
+
+    private static void ApplySeekRatio(SeekBar bar, double ratio)
+    {
+        var width = bar.Root.ActualWidth;
+        if (width <= 0) return;
+        bar.Fill.ScaleX = ratio;
+        var thumbWidth = bar.ThumbElement.ActualWidth;
+        bar.Thumb.X = Math.Clamp(ratio * width - thumbWidth / 2, 0, Math.Max(0, width - thumbWidth));
+    }
+
+    private void OnSeekBarPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not Grid root || !_seekBars.TryGetValue(root, out var bar)) return;
+        root.CapturePointer(e.Pointer);
+        root.Focus(FocusState.Pointer);
+        bar.Seeking = true;
+        bar.Strip.BeginSeek();
+        SeekToPointer(bar, e);
+        ShowTip(bar);
+        e.Handled = true;
+    }
+
+    private void OnSeekBarPointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not Grid root || !_seekBars.TryGetValue(root, out var bar) || !bar.Seeking) return;
+        SeekToPointer(bar, e);
+        PositionTip(bar);
+    }
+
+    private void OnSeekBarPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        if (sender is not Grid root || !_seekBars.TryGetValue(root, out var bar) || !bar.Seeking) return;
+        bar.Seeking = false;
+        HideTip(bar);
+        root.ReleasePointerCapture(e.Pointer);
+        _ = bar.Strip.EndSeekAsync(bar.PendingSeconds);
+    }
+
+    private static void SeekToPointer(SeekBar bar, PointerRoutedEventArgs e)
+    {
+        var width = bar.Root.ActualWidth;
+        if (width <= 0) return;
+        var ratio = Math.Clamp(e.GetCurrentPoint(bar.Root).Position.X / width, 0, 1);
+        bar.PendingSeconds = ratio * bar.Strip.DurationSeconds;
+        ApplySeekRatio(bar, ratio);
+    }
+
+    private void OnSeekBarKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (sender is not Grid root || !_seekBars.TryGetValue(root, out var bar)) return;
         if (e.Key == VirtualKey.Escape)
         {
-            strip.CancelSeek();
+            if (!bar.Seeking) return;
+            bar.Seeking = false;
+            HideTip(bar);
+            bar.Strip.CancelSeek();
+            RenderSeekBar(bar);
             e.Handled = true;
             return;
         }
-        if (IsSliderNudgeKey(e.Key)) strip.BeginSeek();
+        if (!IsSliderNudgeKey(e.Key)) return;
+        var duration = bar.Strip.DurationSeconds;
+        if (duration <= 0) return;
+        if (!bar.Seeking)
+        {
+            bar.Seeking = true;
+            bar.Strip.BeginSeek();
+            bar.PendingSeconds = Math.Clamp(bar.Strip.PositionSeconds, 0, duration);
+        }
+        bar.PendingSeconds = e.Key switch
+        {
+            VirtualKey.Left or VirtualKey.Down => Math.Clamp(bar.PendingSeconds - SeekNudgeSeconds, 0, duration),
+            VirtualKey.Right or VirtualKey.Up => Math.Clamp(bar.PendingSeconds + SeekNudgeSeconds, 0, duration),
+            VirtualKey.PageDown => Math.Clamp(bar.PendingSeconds - SeekPageSeconds, 0, duration),
+            VirtualKey.PageUp => Math.Clamp(bar.PendingSeconds + SeekPageSeconds, 0, duration),
+            VirtualKey.Home => 0,
+            VirtualKey.End => duration,
+            _ => bar.PendingSeconds,
+        };
+        ApplySeekRatio(bar, bar.PendingSeconds / duration);
+        ShowTip(bar);
+        e.Handled = true;
     }
 
-    private void OnSeekSliderKeyUp(object sender, KeyRoutedEventArgs e)
+    private void OnSeekBarKeyUp(object sender, KeyRoutedEventArgs e)
     {
-        if (IsSliderNudgeKey(e.Key) && sender is Slider { Tag: NowPlayingStrip strip } slider) _ = strip.EndSeekAsync(slider.Value);
+        if (sender is not Grid root || !_seekBars.TryGetValue(root, out var bar)) return;
+        if (bar.Seeking && IsSliderNudgeKey(e.Key))
+        {
+            bar.Seeking = false;
+            HideTip(bar);
+            _ = bar.Strip.EndSeekAsync(bar.PendingSeconds);
+            e.Handled = true;
+        }
+    }
+
+    // The drag/keyboard-seek timestamp bubble (a Popup), positioned to sit centred above the thumb.
+    private void ShowTip(SeekBar bar)
+    {
+        if (bar.Tip is null) return;
+        PositionTip(bar);
+        bar.Tip.IsOpen = true;
+    }
+
+    private static void HideTip(SeekBar bar)
+    {
+        if (bar.Tip is not null) bar.Tip.IsOpen = false;
+    }
+
+    private static void PositionTip(SeekBar bar)
+    {
+        if (bar.Tip?.Child is not FrameworkElement bubble || bar.TipText is null) return;
+        bar.TipText.Text = FormatSeekTime(bar.PendingSeconds);
+        bubble.Measure(new Windows.Foundation.Size(double.PositiveInfinity, double.PositiveInfinity));
+        var width = bubble.DesiredSize.Width;
+        var thumbCentre = bar.Thumb.X + bar.ThumbElement.ActualWidth / 2;
+        bar.Tip.HorizontalOffset = Math.Clamp(thumbCentre - width / 2, 0, Math.Max(0, bar.Root.ActualWidth - width));
+        bar.Tip.VerticalOffset = -(bubble.DesiredSize.Height + 4);
+    }
+
+    private static string FormatSeekTime(double seconds)
+    {
+        if (double.IsNaN(seconds) || seconds < 0) seconds = 0;
+        var t = TimeSpan.FromSeconds(seconds);
+        return t.TotalHours >= 1
+            ? $"{(int)t.TotalHours}:{t.Minutes:00}:{t.Seconds:00}"
+            : $"{t.Minutes}:{t.Seconds:00}";
     }
 
     // ---- Context-menu construction (the device + app-chip menus share one item list) ----

--- a/src/Earmark.App/ViewModels/NowPlayingStrip.cs
+++ b/src/Earmark.App/ViewModels/NowPlayingStrip.cs
@@ -30,10 +30,20 @@ public partial class NowPlayingStrip : ObservableObject
     // YouTube Music's auto-generated channels report the artist as "<Artist> - Topic".
     private static readonly Regex TopicSuffix =
         new(@"\s*[-\u2013\u2014]\s*topic\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    // Strips any ()/[] group containing "Official" (e.g. "(Official Video)", "[Official Music Video]",
-    // "[Official Channel]"). Leading whitespace is absorbed so the trailing trim leaves no double spaces.
-    private static readonly Regex OfficialTag =
-        new(@"\s*[\(\[][^\)\]]*\bofficial\b[^\)\]]*[\)\]]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    // Matches one ()/[] group (leading whitespace absorbed so removal leaves no double space). Whether
+    // the group is dropped is decided per-match by IsDescriptorNoise, not by the pattern alone.
+    private static readonly Regex BracketGroup =
+        new(@"\s*[\(\[]([^\)\]]*)[\)\]]", RegexOptions.Compiled);
+    private static readonly Regex WordToken = new(@"[\p{L}\p{N}]+", RegexOptions.Compiled);
+    // Words that mark a bracketed group as platform/format noise rather than part of the song name:
+    // "(Official Video)", "(Original Video)", "[Official Music Video]", "(Lyric Video)", "(Audio)",
+    // "(Visualizer)", "(HD)", "(4K)". A group is stripped only when EVERY word in it is noise, so a real
+    // parenthesised qualifier survives - "(Get Out)", "(feat. Drake)", "(Remix)", "(Original Mix)".
+    private static readonly HashSet<string> DescriptorNoise = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "official", "video", "audio", "lyric", "lyrics", "lyrical", "visualizer", "visualiser",
+        "music", "original", "channel", "hd", "hq", "uhd", "sd", "4k", "8k", "mv", "vevo",
+    };
 
     private readonly INowPlayingService _service;
     private readonly INowPlayingArtworkService _artwork;
@@ -51,6 +61,15 @@ public partial class NowPlayingStrip : ObservableObject
     private bool _pendingSeek;
     private double _pendingSeconds;
     private int _pendingTicks;
+    // Smoothed playback clock. SMTC reports Position truncated to whole seconds with a precise
+    // LastUpdatedTime, so re-anchoring to each ~1 Hz snapshot snaps the bar backward by the lost
+    // fraction every second - the visible "jump". Instead we run our own clock forward at 1x and only
+    // hard-resync it on a genuine discontinuity (seek, track change, pause/resume, stall), ignoring the
+    // sub-second truncation noise so playback advances smoothly. Absolute (matches PositionSeconds).
+    private const double ResyncThresholdSeconds = 1.5;
+    private double _clockSeconds;
+    private DateTime _clockAnchorUtc;
+    private bool _clockValid;
 
     public NowPlayingStrip(
         AppChip chip,
@@ -64,6 +83,7 @@ public partial class NowPlayingStrip : ObservableObject
         _service = service ?? throw new ArgumentNullException(nameof(service));
         _artwork = artwork ?? throw new ArgumentNullException(nameof(artwork));
         _meterOptions = meterOptions ?? throw new ArgumentNullException(nameof(meterOptions));
+        SyncClock(playbackChanged: false); // seed the clock from the initial snapshot
         _ = RefreshBackdropAsync();
     }
 
@@ -114,12 +134,40 @@ public partial class NowPlayingStrip : ObservableObject
     private double LivePositionSeconds()
     {
         if (!_info.HasTimeline) return 0;
-        var pos = _info.PositionSeconds;
-        if (_info.IsPlaying)
-        {
-            pos += (DateTime.UtcNow - _info.LastUpdatedUtc).TotalSeconds;
-        }
+        var pos = _clockValid ? ClockNowSeconds() : SnapshotNowSeconds();
         return Math.Clamp(pos, _info.StartSeconds, _info.EndSeconds) - _info.StartSeconds;
+    }
+
+    /// <summary>Absolute position the current SMTC snapshot reports right now (raw value plus the
+    /// elapsed-since-update interpolation while playing). The clock resyncs to this.</summary>
+    private double SnapshotNowSeconds()
+    {
+        var pos = _info.PositionSeconds;
+        if (_info.IsPlaying) pos += (DateTime.UtcNow - _info.LastUpdatedUtc).TotalSeconds;
+        return pos;
+    }
+
+    /// <summary>Absolute position the smoothed clock shows right now: its anchor plus real elapsed time
+    /// while playing (frozen while paused).</summary>
+    private double ClockNowSeconds()
+    {
+        var pos = _clockSeconds;
+        if (_info.IsPlaying) pos += (DateTime.UtcNow - _clockAnchorUtc).TotalSeconds;
+        return pos;
+    }
+
+    /// <summary>Reconciles the smoothed clock with the current snapshot. Keeps it running continuously
+    /// (no visible jump) unless the snapshot diverges past the resync threshold or the play/pause state
+    /// flipped - a real discontinuity worth snapping to.</summary>
+    private void SyncClock(bool playbackChanged)
+    {
+        if (!_info.HasTimeline) { _clockValid = false; return; }
+        var target = SnapshotNowSeconds();
+        var current = ClockNowSeconds();
+        var resync = !_clockValid || playbackChanged || Math.Abs(target - current) > ResyncThresholdSeconds;
+        _clockSeconds = resync ? target : current;
+        _clockAnchorUtc = DateTime.UtcNow;
+        _clockValid = true;
     }
 
     /// <summary>Begins a user seek drag: freezes the position at the current spot so neither the 20 Hz
@@ -196,8 +244,12 @@ public partial class NowPlayingStrip : ObservableObject
             OnPropertyChanged(nameof(IsLive));
         }
         if (Math.Abs(old.DurationSeconds - info.DurationSeconds) > 0.001) OnPropertyChanged(nameof(DurationSeconds));
-        // Don't push a fresh position onto the seek slider mid-drag, or the thumb jumps.
-        if (!_seeking) OnPropertyChanged(nameof(PositionSeconds));
+        // Don't reconcile the clock or push a fresh position onto the seek slider mid-drag, or the thumb jumps.
+        if (!_seeking)
+        {
+            SyncClock(playbackChanged: old.IsPlaying != info.IsPlaying);
+            OnPropertyChanged(nameof(PositionSeconds));
+        }
         _ = RefreshBackdropAsync();
     }
 
@@ -238,7 +290,7 @@ public partial class NowPlayingStrip : ObservableObject
     private static string CleanTitle(string title, string artist)
     {
         if (string.IsNullOrWhiteSpace(title)) return title;
-        title = OfficialTag.Replace(title, string.Empty).Trim();
+        title = StripDescriptorTags(title).Trim();
         if (string.IsNullOrWhiteSpace(artist)) return title;
         var m = ArtistPrefix.Match(title);
         if (!m.Success) return title;
@@ -252,7 +304,27 @@ public partial class NowPlayingStrip : ObservableObject
     /// would yield the space-less "KanyeWest".</summary>
     private static string CleanArtist(string artist) =>
         string.IsNullOrWhiteSpace(artist) ? artist
-            : OfficialTag.Replace(TopicSuffix.Replace(artist, string.Empty), string.Empty).Trim();
+            : StripDescriptorTags(TopicSuffix.Replace(artist, string.Empty)).Trim();
+
+    /// <summary>Removes bracketed platform/format tags ("(Official Video)", "(Original Video)", "[Lyric
+    /// Video]", "(Audio)", "(HD)" ...) wherever they sit in the text. A group is dropped only when every
+    /// word in it is a known descriptor (<see cref="DescriptorNoise"/>), so a meaningful parenthesised
+    /// qualifier - "(Get Out)", "(feat. X)", "(Remix)" - is preserved. Bare numbers (years like
+    /// "(2009)") don't by themselves mark a group as noise.</summary>
+    private static string StripDescriptorTags(string text) =>
+        BracketGroup.Replace(text, m => IsDescriptorNoise(m.Groups[1].Value) ? string.Empty : m.Value);
+
+    private static bool IsDescriptorNoise(string inner)
+    {
+        var noise = false;
+        foreach (Match token in WordToken.Matches(inner))
+        {
+            if (token.Value.All(char.IsDigit)) continue;          // bare number: doesn't decide
+            if (!DescriptorNoise.Contains(token.Value)) return false; // a real word: keep the group
+            noise = true;
+        }
+        return noise;
+    }
 
     /// <summary>Reduces an artist/channel name to a comparable core: strips a trailing "VEVO" or
     /// "- Topic", then keeps only letters/digits, lowercased. "KanyeWestVEVO", "Kanye West" and


### PR DESCRIPTION
Reworks the now-playing seek bar so the thumb and fill glide instead of stepping once a second. A WinUI Slider positions its thumb through a layout pass that rounds to a whole pixel each frame, so on a narrow card (~1px/second) it could only move once a second however smooth the bound value was. The bar is now a custom element whose track/fill/thumb are positioned by RenderTransforms (sub-pixel, render-thread) driven from the strip position. Pointer and keyboard seeking are handled directly (drag to scrub, commit on release, Esc cancels, arrows/Page/Home/End nudge), with a timestamp bubble that follows the thumb while seeking. A view-model clock interpolates the position at 20 Hz and absorbs the per-snapshot truncation so there are no backsteps.

Also on this branch:

---

fix: drop platform tags from now-playing titles

docs: ask for an optional mockup in feature request template